### PR TITLE
Make hyperlinks non-findable

### DIFF
--- a/static/js/play.js
+++ b/static/js/play.js
@@ -89,7 +89,14 @@ async function loadPage(page) {
 
     const title = body["parse"]["title"]
 
-    document.getElementById("wikipedia-frame").innerHTML = body["parse"]["text"]["*"]
+    let frameBody = document.getElementById("wikipedia-frame")
+    frameBody.innerHTML = body["parse"]["text"]["*"]
+    frameBody.querySelectorAll("a").forEach(function(a) {
+        a.innerHTML = '<div style="display:inline-block">' + a.text.split('').map(function(character) {
+            return '<div style="display:inline-block">' + character.replace(/\s/g, '&nbsp;') + '</div>'
+        }).join('') + '</div>'
+    });
+
     document.getElementById("title").innerHTML = "<h1><i>"+title+"</i></h1>"
     
 

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -56,7 +56,7 @@ a {
     text-decoration: none !important;
 }
 
-a:hover {
+a:hover, a:hover * {
     text-decoration: underline !important;
 }
 


### PR DESCRIPTION
- Embeds hyperlink characters into `div` blocks to make them non-searchable in case players bypass search block.