### PR TITLE
Minor: Set default join_date on users upon creation

### DIFF
--- a/scripts/createDB.py
+++ b/scripts/createDB.py
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `users` (
     `hash` CHAR(60),
     `email` VARCHAR(255) NOT NULL UNIQUE,
     `email_confirmed` BOOLEAN NOT NULL DEFAULT 0,
-    `join_date` DATE NOT NULL,
+    `join_date` DATE NOT NULL DEFAULT (CURRENT_DATE()),
     `admin` BOOLEAN NOT NULL DEFAULT 0,
     PRIMARY KEY (`user_id`)
 );


### PR DESCRIPTION
Closes #163 by setting join_date to `CURRENT_DATE()`

New behavior: 
```
(env) jasonwong@jasonmbp scripts % python configure.py 
Would you like to setup configuration for production? (y/n): n
Would you like to setup an admin account? (y/n): y
Admin account username (leave blank for 'admin'): 
Admin account email (currently not used): 
Admin account password: 
Reenter password: 
Admin User admin added
Would you like to setup another admin account? (y/n): n
```