### PR TITLE
Clean up leaderboard logic for first run

### DIFF
--- a/apis/prompts.py
+++ b/apis/prompts.py
@@ -197,13 +197,14 @@ def get_prompt_leaderboard(id, run_id):
     SELECT run_id, path, runs.user_id, username, TIMESTAMPDIFF(MICROSECOND, runs.start_time, runs.end_time) AS run_time
     FROM runs
     JOIN (
-            SELECT users.user_id, username, MIN(start_time) AS first_run 
+            SELECT users.user_id, username, MIN(run_id) AS first_run 
             FROM runs
             JOIN users ON users.user_id=runs.user_id
-            WHERE prompt_id=%s AND end_time IS NOT NULL
+            WHERE prompt_id=%s 
             GROUP BY user_id
     ) firsts
-    ON firsts.user_id=runs.user_id AND first_run=start_time
+    ON firsts.user_id=runs.user_id AND first_run=run_id
+    WHERE end_time IS NOT NULL
     '''
 
     args = [id]

--- a/apis/runs.py
+++ b/apis/runs.py
@@ -19,10 +19,9 @@ def create_run():
     Returns the user ID of the run created.
     '''
 
-    query = "INSERT INTO `runs` (`start_time`,`prompt_id`,`user_id`) VALUES (%s, %s, %s)"
+    query = "INSERT INTO `runs` (`prompt_id`,`user_id`) VALUES (%s, %s)"
     sel_query = "SELECT LAST_INSERT_ID()"
 
-    start_time = datetime.fromtimestamp(request.json['start_time']/1000)
     prompt_id = request.json['prompt_id']
 
     if ('user_id' in session):
@@ -34,9 +33,8 @@ def create_run():
 
     db = get_db()
     with db.cursor() as cursor:
-        print(cursor.mogrify(query, (start_time, prompt_id, user_id)))
-        result = cursor.execute(query, (start_time, prompt_id, user_id))
-        
+        print(cursor.mogrify(query, (prompt_id, user_id)))
+        cursor.execute(query, (prompt_id, user_id))
         cursor.execute(sel_query)
         id = cursor.fetchone()[0]
         db.commit()

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -287,10 +287,7 @@ async function countdownOnLoad(start, end) {
 }
 
 async function saveRun() {
-    startTime = Date.now();
-    
     const reqBody = {
-        "start_time": startTime,
         "prompt_id": prompt_id,
     }
 

--- a/templates/prompt.html
+++ b/templates/prompt.html
@@ -29,7 +29,7 @@
                     <tbody>
                         <tr v-if="currentRunPosition === -1">
                             <td>[[currentRunRank]]</td>
-                            <td v-if="currentRun.username">[[currentRun.username]]</td>
+                            <td v-if="currentRun.username"><strong>[[currentRun.username]]</strong></td>
                             <td v-else><strong>You</strong></td>
                             <td>[[(currentRun.run_time/1000000).toFixed(3)]] s</td>
                             <td>[[currentRun.path]]</td>
@@ -42,7 +42,7 @@
                         </tr>
                         <tr v-for="(run, index) in renderedRuns">
                             <td>[[getRenderedRank(index)]]</td>
-                            <td v-if="run.username">[[run.username]]</td>
+                            <td v-if="run.username"><strong>[[run.username]]</strong></td>
                             <td v-else><strong>You</strong></td>
                             <td>[[(run.run_time/1000000).toFixed(3)]] s</td>
                             <td>[[run.path]]</td>
@@ -55,7 +55,7 @@
                         </tr>
                         <tr v-if="currentRunPosition === 1">
                             <td>[[currentRunRank]]</td>
-                            <td v-if="currentRun.username">[[currentRun.username]]</td>
+                            <td v-if="currentRun.username"><strong>[[currentRun.username]]</strong></td>
                             <td v-else><strong>You</strong></td>
                             <td>[[(currentRun.run_time/1000000).toFixed(3)]] s</td>
                             <td>[[currentRun.path]]</td>


### PR DESCRIPTION
#155 was mostly handled in #159, this PR is just some cleanup so we can close #155 and #24 .

- Log run in database with NULL start time upon clicking a prompt
-> Need to run `ALTER TABLE runs MODIFY start_time TIMESTAMP(3) NULL;` in prod db
- Leaderboard query for first run changed to use earliest `run_id` of a user instead of earliest `start_time`

Verified user run appears on leaderboard only if user is logged in and completed the run on their first try

Also fixes #167 