### PR TITLE
Display link to leaderboard in archive page

### DIFF
--- a/apis/sprints.py
+++ b/apis/sprints.py
@@ -98,7 +98,7 @@ def get_archive_prompts():
         limit = int(request.args.get('limit', 20))
         offset = int(request.args.get('offset', 0))
         
-        sprints, num_prompts = prompts.get_archive_prompts("sprint", offset=offset, limit=limit)
+        sprints, num_prompts = prompts.get_archive_prompts("sprint", offset=offset, limit=limit, user_id=session.get("user_id"))
 
         return jsonify({
             "prompts": sprints,

--- a/static/js/archive.js
+++ b/static/js/archive.js
@@ -14,10 +14,15 @@ var app = new Vue({
         numPages: 0,
 
         limit: 0,
-        offset: 0
+        offset: 0,
+        loggedIn: false,
     },
 
     created: async function() {
+        if ("username" in serverData) {
+            this.loggedIn = true;
+        }
+        
         const response = await fetch(`/api/sprints/archive?limit=${limit}&offset=${offset}`);
         const resp = await response.json();
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -26,6 +26,7 @@
                     <thead>
                         <th scope="col">Release Date</th>
                         <th scope="col">Prompt #</th>
+                        <th v-if="loggedIn" scope="col">Leaderboard</th>
                         <th scope="col">Starting Article</th>
                         <th scope="col">Ending Article</th>
                         <th></th>
@@ -34,6 +35,9 @@
                         <tr v-for="prompt in prompts" v-cloak>
                             <td>[[prompt.active_start.substring(0, 10)]]</td>
                             <td>[[prompt.prompt_id]]<span v-if="prompt.rated">*</span> </td>
+                            <td v-if="loggedIn">
+                                <a v-if="prompt.first_run != null" v-bind:href="'/prompt/' + prompt.prompt_id + '?run_id=' + prompt.first_run">Your Rank</a>
+                            </td>
                             <td>[[prompt.start]]</td>
                             <td>[[prompt.end || '-']]</td>
                             <td><a v-bind:href="'/play/' + prompt.prompt_id">Play</a></td>


### PR DESCRIPTION
I added a column in the archive table for links to leaderboard. Users can only see leaderboard links to games that they've already played. If they're not logged in, the column is just hidden altogether.

I also edited the get_archive_prompts function in prompts.py to left join the user's first run id for each prompt. With this, I set the leaderboard link to "/prompt/{prompt_id}?run_id={first_run}". I did this, as opposed to just simply checking whether they played the game, because I noticed the leaderboard points out your rank more clearly only when you have the run_id param in the web link
