### PR TITLE
prevent loops from being added to path (only append to path if the new page wasn't the most recent visited page)

### DIFF
--- a/static/js/marathon.js
+++ b/static/js/marathon.js
@@ -130,10 +130,7 @@ let app = new Vue({
 
         async pageCallback(page, loadTime) {
 
-            if (this.path.length == 0) {
-                this.path.push(page);
-                this.clicksRemaining -= 1;
-            } else if (this.path[this.path.length - 1] != page) {
+            if (this.path.length == 0 || this.path[this.path.length - 1] != page) {
                 this.path.push(page);
                 this.clicksRemaining -= 1;
             }

--- a/static/js/marathon.js
+++ b/static/js/marathon.js
@@ -132,12 +132,12 @@ let app = new Vue({
 
         async pageCallback(page, loadTime) {
 
-            this.clicksRemaining -= 1;
-
             if (this.path.length == 0) {
                 this.path.push(page);
+                this.clicksRemaining -= 1;
             } else if (this.path[this.path.length - 1] != page) {
                 this.path.push(page);
+                this.clicksRemaining -= 1;
             }
             
             //this.path.push(page);

--- a/static/js/marathon.js
+++ b/static/js/marathon.js
@@ -133,8 +133,14 @@ let app = new Vue({
         async pageCallback(page, loadTime) {
 
             this.clicksRemaining -= 1;
+
+            if (this.path.length == 0) {
+                this.path.push(page);
+            } else if (this.path[this.path.length - 1] != page) {
+                this.path.push(page);
+            }
             
-            this.path.push(page);
+            //this.path.push(page);
             this.currentArticle = page;
 
             this.startTime += loadTime;

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -127,7 +127,13 @@ let app = new Vue({
             this.loading = false;
             this.hover = false;
             // Game logic for sprint mode:
-            this.path.push(page);
+
+            if (this.path.length == 0) {
+                this.path.push(page);
+            } else if (this.path[this.path.length - 1] != page) {
+                this.path.push(page);
+            }
+            //this.path.push(page);
 
             this.currentArticle = page;
 

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -131,9 +131,7 @@ let app = new Vue({
             this.hover = false;
             // Game logic for sprint mode:
 
-            if (this.path.length == 0) {
-                this.path.push(page);
-            } else if (this.path[this.path.length - 1] != page) {
+            if (this.path.length == 0 || this.path[this.path.length - 1] != page) {
                 this.path.push(page);
             }
             //this.path.push(page);


### PR DESCRIPTION
I believe this issue comes from a specific case when there is a link on a page that links to an anchored id on the same page, but does it through a different URL and then a redirect, so its being treated as if its an unique article (adding to path, counting clicks, etc.)

Not sure if there's a good way to handle extra anchor tags that are being treated as new pages (since the URLs might be different through a redirect).

We can instead prevent these loop edges from being counted towards things like the path or clicks for marathon