### PR TITLE
sprint mobile UI fixes

### DIFF
--- a/static/js/modules/game/articleRenderer.js
+++ b/static/js/modules/game/articleRenderer.js
@@ -93,7 +93,7 @@ export class ArticleRenderer {
 
 function hideElements(frame) {
 
-    const hide = ["reference","mw-editsection","reflist","portal","refbegin", "sidebar", "authority-control", "external", "sistersitebox"]
+    const hide = ["reference","mw-editsection","reflist","portal","refbegin", "sidebar", "authority-control", "external", "sistersitebox", "box-More_citations_needed"]
     for(let i=0; i<hide.length; i++) {
         let elements = document.getElementsByClassName(hide[i])
         //console.log("found: " + hide[i] + elements.length)

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -183,15 +183,21 @@ let app = new Vue({
             const vh = window.innerHeight;
             const vw = window.innerWidth;
             const styleObject = new Object();
-            if (this.clientX < vw / 2.0) {
-                styleObject['left'] = `${this.clientX+10}px`;
+
+            if (vw >= 768) {
+                if (this.clientX < vw / 2.0) {
+                    styleObject['left'] = `${this.clientX+10}px`;
+                } else {
+                    styleObject['right'] = `${vw-this.clientX+10}px`;
+                }
+                if (this.clientY < vh / 2.0) {
+                    styleObject['top'] = `${this.clientY+10}px`;
+                } else {
+                    styleObject['bottom'] = `${vh-this.clientY+10}px`;
+                }
             } else {
-                styleObject['right'] = `${vw-this.clientX+10}px`;
-            }
-            if (this.clientY < vh / 2.0) {
-                styleObject['top'] = `${this.clientY+10}px`;
-            } else {
-                styleObject['bottom'] = `${vh-this.clientY+10}px`;
+                styleObject['left'] = '10px';
+                styleObject['bottom'] = `${document.getElementById("time-box-mobile").offsetHeight + 25}px`;
             }
             return styleObject;
         },
@@ -219,12 +225,20 @@ let app = new Vue({
         },
 
         setupPreviews: function() {
-            document.getElementById("wikipedia-frame").querySelectorAll("a").forEach(e => {
-                if (e.hasAttribute("href") && e.getAttribute("href").startsWith("/wiki/")) {
-                    e.addEventListener("mouseenter", this.mouseEnter);
-                    e.addEventListener("mouseleave", this.mouseLeave);
-                }
-            });
+            if (screen.width >= 768) {
+                document.getElementById("wikipedia-frame").querySelectorAll("a").forEach(e => {
+                    if (e.hasAttribute("href") && e.getAttribute("href").startsWith("/wiki/")) {
+                        e.addEventListener("mouseenter", this.mouseEnter);
+                        e.addEventListener("mouseleave", this.mouseLeave);
+                    }
+                });
+            } 
+        },
+
+        mobilePreviewClick: function (e) {
+            //console.log("click function")
+            if (this.loading) this.mouseLeave();
+            else this.mouseEnter(e);
         }
 
     }
@@ -232,7 +246,9 @@ let app = new Vue({
 
 function setMargin() {
     const element = document.getElementById("time-box");
-    let margin = (element.offsetHeight + 25) > 100 ? (element.offsetHeight + 25) : 100
+    const mobile_timebox_el = document.getElementById("time-box-mobile");
+    let margin = Math.max((element.offsetHeight + 25), (mobile_timebox_el.offsetHeight + 25), 100);
+    //(element.offsetHeight + 25) > 100 ? (element.offsetHeight + 25) : 100
     document.getElementById("wikipedia-frame").style.marginBottom = margin +"px";
 }
 

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -75,7 +75,6 @@ a:hover, a:hover * {
     background-color: #F8F8F8;
     margin-bottom: 15px;
     border: 2px solid #000000 !important;
-
 }
 
 @media (max-width: 1200px) {
@@ -95,6 +94,24 @@ a:hover, a:hover * {
 @media (max-width: 767px) {
     .checkpointCol {
         display: none;
+    }
+
+    .show-on-mobile {
+        display: block;
+    }
+
+    .show-on-desktop {
+        display: none;
+    }
+}
+
+@media (min-width: 768px) {
+    .show-on-mobile {
+        display: none;
+    }
+
+    .show-on-desktop {
+        display: block;
     }
 }
 

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -77,6 +77,16 @@ a:hover, a:hover * {
     border: 2px solid #000000 !important;
 }
 
+.HUDwrapper-mobile {
+    position:fixed;
+    z-index: 1000;
+    width: 100%;
+    bottom: 0;
+    left:0;
+    background-color: #F8F8F8;
+    border-top: 3px solid #000000 !important;
+}
+
 @media (max-width: 1200px) {
     .mirroredimgblock {
         visibility:hidden !important;

--- a/static/stylesheets/play.css
+++ b/static/stylesheets/play.css
@@ -155,3 +155,14 @@
 	top: 0;
 	left: 0;
 }
+
+@media (max-width: 767px) {
+    .main-text {
+        font-size: 14px;
+    }
+}
+
+.HUDwrapper-mobile {
+    padding: 5px 10px;
+    font-size: 14px;
+}

--- a/static/stylesheets/play.css
+++ b/static/stylesheets/play.css
@@ -162,7 +162,8 @@
     }
 }
 
-.HUDwrapper-mobile {
+.HUDwrapper-mobile-inner-container {
     padding: 5px 10px;
     font-size: 14px;
 }
+

--- a/templates/play.html
+++ b/templates/play.html
@@ -48,6 +48,8 @@
                     End Article: <strong>[[endArticle]]</strong>
                     <small style="cursor: default; font-size: 15px;" :href="`/wiki/${endArticle}`" @click="mobilePreviewClick(event)" id="mobile-end-article-info">ⓘ</small>
                     <br>
+                    Current Article: <strong>[[currentArticle]]</strong>
+                    <br>
                     Time Elapsed: <strong>[[elapsed.toFixed(3)]] s</strong>
                 </div>
             </div>

--- a/templates/play.html
+++ b/templates/play.html
@@ -17,25 +17,44 @@
 
 <div id="app">
 
-    <div v-show="started && !finished" id="time-box" class="HUDwrapper container">
-        <div class="row flex-row">
-            <div class="col-sm-auto text-nowrap px-4 py-2">
-                Start Article<br><strong>[[startArticle]]</strong>
-                <br>Current Article<br><strong>[[currentArticle]]</strong>
-            </div>
-            <div class="col-sm-auto text-nowrap px-4 py-2">
-                End Article<br><strong>[[endArticle]] </strong>
-                <small style="cursor: default;" :href="`/wiki/${endArticle}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
-                    ⓘ
-                </small>
-            </div>
-            <div class="col-sm-auto text-nowrap px-4 py-2">
-                Time Elapsed<br><strong>[[elapsed.toFixed(3)]] s</strong>
+    <div v-show="started && !finished">
+
+        <div class="show-on-desktop">
+
+            <div id="time-box" class="HUDwrapper container">
+                <div class="row flex-row">
+                    <div class="col-sm-auto text-nowrap px-4 py-2">
+                        Start Article<br><strong>[[startArticle]]</strong>
+                        <br>Current Article<br><strong>[[currentArticle]]</strong>
+                    </div>
+                    <div class="col-sm-auto text-nowrap px-4 py-2">
+                        End Article<br><strong>[[endArticle]] </strong>
+                        <small style="cursor: default;" :href="`/wiki/${endArticle}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
+                            ⓘ
+                        </small>
+                    </div>
+                    <div class="col-sm-auto text-nowrap px-4 py-2">
+                        Time Elapsed<br><strong>[[elapsed.toFixed(3)]] s</strong>
+                    </div>
+                </div>
+            </div>    
+        </div>
+
+        <div class="show-on-mobile">
+            <div class="HUDwrapper" id="time-box-mobile">
+                <div class="HUDwrapper-mobile">
+                    Start Article: <strong>[[startArticle]]</strong>
+                    <br>
+                    End Article: <strong>[[endArticle]]</strong>
+                    <small style="cursor: default; font-size: 15px;" :href="`/wiki/${endArticle}`" @click="mobilePreviewClick(event)" id="mobile-end-article-info">ⓘ</small>
+                    <br>
+                    Time Elapsed: <strong>[[elapsed.toFixed(3)]] s</strong>
+                </div>
             </div>
         </div>
-    </div>
 
-    <div v-if="loading && hover" v-html="displayPreview()" class="tooltip-container" :style="computePosition()"></div>
+        <div v-if="loading && hover" v-html="displayPreview()" class="tooltip-container" :style="computePosition()"></div>
+    </div>
 
     <countdown-timer id="time-box"
         v-bind:start-article="startArticle"
@@ -58,7 +77,7 @@
     ></finish-page>
 
     <div v-show="started && !finished" id="main">
-        <div id="wikipedia-frame"></div>
+        <div id="wikipedia-frame" class="main-text"></div>
     </div>
 
 </div>

--- a/templates/play.html
+++ b/templates/play.html
@@ -41,8 +41,8 @@
         </div>
 
         <div class="show-on-mobile">
-            <div class="HUDwrapper" id="time-box-mobile">
-                <div class="HUDwrapper-mobile">
+            <div class="HUDwrapper-mobile" id="time-box-mobile">
+                <div class="HUDwrapper-mobile-inner-container">
                     Start Article: <strong>[[startArticle]]</strong>
                     <br>
                     End Article: <strong>[[endArticle]]</strong>


### PR DESCRIPTION
First round of fixes for the mobile UI:

- Reduced article and timebox font size
- reduced margins/padding to make the timebox much more compact on mobile
- removed display page preview on "hover" (I couldn't think of a way for mobile users to also get page previews in the article itself), 
- Kept the end article preview icon (now a click toggle instead of on hover)