### PR TITLE
Add previews to marathon and refactor articleRenderer

### DIFF
--- a/static/js/marathon.js
+++ b/static/js/marathon.js
@@ -60,6 +60,7 @@ let app = new Vue({
         renderer: null,
         hover: false,
         loading: false,
+        blocker: false,
 
         clientX: 0,
         clientY: 0
@@ -227,15 +228,6 @@ let app = new Vue({
             this.runId = await submitRun(this.promptId, this.endTime - this.startTime + this.lastTime, this.visitedCheckpoints, this.path, finished);
             removeSave(PROMPT_ID);
         
-        },
-
-        displayPreview: function() {
-            let html = "";
-            if ("originalimage" in this.articlePreview) {
-                html += '<img src="' + this.articlePreview["originalimage"]["source"] + '"/>';
-            }
-            html += '<div>' + this.articlePreview["extract_html"] + '</div>';
-            return html;
         },
 
         computePosition: function() {

--- a/static/js/marathon.js
+++ b/static/js/marathon.js
@@ -7,6 +7,7 @@ import { CountdownTimer } from "./modules/game/marathon/countdown.js";
 import { MarathonHelp } from "./modules/game/marathon/help.js";
 import { FinishPage } from "./modules/game/marathon/finish.js";
 import { ArticleRenderer } from "./modules/game/articleRenderer.js";
+import { PagePreview } from "./modules/game/pagePreview.js";
 
 import { basicCannon, fireworks, side } from "./modules/confetti.js";
 
@@ -21,6 +22,7 @@ let app = new Vue({
         'countdown-timer': CountdownTimer,
         'finish-page': FinishPage,
         'marathon-help': MarathonHelp,
+        'page-preview': PagePreview
     },
     data: {
 
@@ -34,7 +36,7 @@ let app = new Vue({
         startArticle: "",    //For all game modes, this is the first article to load
         lastArticle: "",
         currentArticle: "",
-        articlePreview: "",
+        articlePreview: null,
         path: [],             //array to store the user's current path so far, submitted with run
 
         promptId: 0,        //Unique prompt id to load, this should be identical to 'const PROMPT_ID', but is mostly used for display
@@ -58,9 +60,8 @@ let app = new Vue({
         saved: false,
 
         renderer: null,
-        hover: false,
-        loading: false,
-        blocker: false,
+        showPreview: false,
+        showPreviewBgUnderlay: false,
 
         clientX: 0,
         clientY: 0
@@ -137,8 +138,8 @@ let app = new Vue({
 
         pageCallback: function(page, loadTime) {
 
-            this.loading = false;
-            this.hover = false;
+            this.showPreview = false;
+            this.articlePreview = null;
 
             if (this.path.length == 0 || this.path[this.path.length - 1] != page) {
                 this.path.push(page);
@@ -230,33 +231,15 @@ let app = new Vue({
         
         },
 
-        computePosition: function() {
-            const vh = window.innerHeight;
-            const vw = window.innerWidth;
-            const styleObject = new Object();
-            if (this.clientX < vw / 2.0) {
-                styleObject['left'] = `${this.clientX+10}px`;
-            } else {
-                styleObject['right'] = `${vw-this.clientX+10}px`;
-            }
-            if (this.clientY < vh / 2.0) {
-                styleObject['top'] = `${this.clientY+10}px`;
-            } else {
-                styleObject['bottom'] = `${vh-this.clientY+10}px`;
-            }
-            return styleObject;
-        },
-
         mouseEnter: function(e) {
-            this.loading = true;
+            this.showPreview = true;
             const href = e.currentTarget.getAttribute("href");
             const title = href.split('/wiki/').pop();
             // const promise1 = getArticleSummary(title);
             // const promise2 = new Promise(resolve => setTimeout(resolve, 500));
             getArticleSummary(title).then(resp => {
-                if (this.loading) {
+                if (this.showPreview) {
                     this.articlePreview = resp;
-                    this.hover = true;
                     this.clientX = e.clientX;
                     this.clientY = e.clientY;
                 }
@@ -264,9 +247,8 @@ let app = new Vue({
         },
 
         mouseLeave: function() {
-            this.loading = false;
-            this.hover = false;
-            this.articlePreview = '';
+            this.showPreview = false;
+            this.articlePreview = null;
         }
 
     }

--- a/static/js/modules/game/articleRenderer.js
+++ b/static/js/modules/game/articleRenderer.js
@@ -33,7 +33,7 @@ export class ArticleRenderer {
             this.frame.querySelectorAll("a, area").forEach((el) => {
                 // Arrow function to prevent this from being overwritten
                 el.onclick = (e) => this.handleWikipediaLink(e);
-                if (el.hasAttribute("href") && el.getAttribute("href").startsWith("/wiki/")) {
+                if (window.screen.width >= 768 && el.hasAttribute("href") && el.getAttribute("href").startsWith("/wiki/")) {
                     el.onmouseenter = this.mouseEnter;
                     el.onmouseleave = this.mouseLeave;
                 }
@@ -87,9 +87,10 @@ export class ArticleRenderer {
 }
 
 function setMargin(frame) {
-    const element = document.getElementById("time-box");
-    let margin = (element.offsetHeight + 25) > 250 ? (element.offsetHeight + 25) : 250;
-    frame.style.marginBottom = margin +"px";
+    const desktop_ht = document.getElementById("time-box") ? document.getElementById("time-box").offsetHeight : 225;
+    const mobile_ht = document.getElementById("time-box-mobile") ? document.getElementById("time-box-mobile").offsetHeight : 225;
+    const margin = Math.max(desktop_ht, mobile_ht, 225) + 25;
+    frame.style.marginBottom = margin + "px";
 }
 
 function hideElements(frame) {

--- a/static/js/modules/game/articleRenderer.js
+++ b/static/js/modules/game/articleRenderer.js
@@ -5,47 +5,44 @@ export class ArticleRenderer {
     /* frame: DOM element (i.e. through getElementById) to render article in
      * pageCallback: Called upon loading an article, should expect new page and load time
      */
-    constructor(frame, pageCallback, setupPreviews) {
+    constructor(frame, pageCallback, mouseEnter, mouseLeave) {
         this.frame = frame;
         this.pageCallback = pageCallback;
-        this.setupPreviews = setupPreviews;
+        this.mouseEnter = mouseEnter;
+        this.mouseLeave = mouseLeave;
     }
 
     async loadPage(page) {
-
-        const body = await getArticle(page);
-
-        this.frame.innerHTML = body["text"]["*"];
-
-        // Create title
-        let titleEl = document.createElement("div");
-        titleEl.innerHTML = "<h1><i>" + body["title"] + "</i></h1>";
-        this.frame.insertBefore(titleEl, this.frame.firstChild);
-
-
-        hideElements(this.frame);
-        // disableFindableLinks(this.frame);
-        stripNamespaceLinks(this.frame);
-
-
-        this.frame.querySelectorAll("a, area").forEach((el) => {
-            // Arrow function to prevent this from being overwritten
-            el.onclick = (e) => this.handleWikipediaLink(e);
-        });
-
-        window.scrollTo(0, 0);
-
-        return body["title"]
-    }
-
-    async loadPageWrapper(page) {
-
         try {
             const startTime = Date.now();
-            const title = await this.loadPage(page);
+            const body = await getArticle(page);
 
-            this.setupPreviews();
-            this.pageCallback(title, Date.now() - startTime);
+            this.frame.innerHTML = body["text"]["*"];
+
+            // Create title
+            let titleEl = document.createElement("div");
+            titleEl.innerHTML = "<h1><i>" + body["title"] + "</i></h1>";
+            this.frame.insertBefore(titleEl, this.frame.firstChild);
+
+
+            hideElements(this.frame);
+            // disableFindableLinks(this.frame);
+            stripNamespaceLinks(this.frame);
+
+
+            this.frame.querySelectorAll("a, area").forEach((el) => {
+                // Arrow function to prevent this from being overwritten
+                el.onclick = (e) => this.handleWikipediaLink(e);
+                if (el.hasAttribute("href") && el.getAttribute("href").startsWith("/wiki/")) {
+                    el.onmouseenter = this.mouseEnter;
+                    el.onmouseleave = this.mouseLeave;
+                }
+            });
+
+            window.scrollTo(0, 0);
+
+            this.pageCallback(body["title"], Date.now() - startTime);
+            setMargin(this.frame);
 
         } catch (error) {
 
@@ -59,15 +56,13 @@ export class ArticleRenderer {
     }
 
 
-    handleWikipediaLink(e)
-    {
+    handleWikipediaLink(e) {
         e.preventDefault();
 
         const linkEl = e.currentTarget;
 
         if (linkEl.getAttribute("href").substring(0, 1) === "#") {
             let a = linkEl.getAttribute("href").substring(1);
-            //console.log(a);
             document.getElementById(a).scrollIntoView();
 
         } else {
@@ -86,12 +81,16 @@ export class ArticleRenderer {
             });
 
             // Remove "/wiki/" from string
-            this.loadPageWrapper(linkEl.getAttribute("href").substring(6))
+            this.loadPage(linkEl.getAttribute("href").substring(6))
         }
     }
 }
 
-
+function setMargin(frame) {
+    const element = document.getElementById("time-box");
+    let margin = (element.offsetHeight + 25) > 250 ? (element.offsetHeight + 25) : 250;
+    frame.style.marginBottom = margin +"px";
+}
 
 function hideElements(frame) {
 
@@ -146,7 +145,6 @@ function hideElements(frame) {
     }
 
 }
-
 
 function stripNamespaceLinks(frame) {
 

--- a/static/js/modules/game/articleRenderer.js
+++ b/static/js/modules/game/articleRenderer.js
@@ -42,7 +42,6 @@ export class ArticleRenderer {
             window.scrollTo(0, 0);
 
             this.pageCallback(body["title"], Date.now() - startTime);
-            setMargin(this.frame);
 
         } catch (error) {
 
@@ -84,13 +83,6 @@ export class ArticleRenderer {
             this.loadPage(linkEl.getAttribute("href").substring(6))
         }
     }
-}
-
-function setMargin(frame) {
-    const desktop_ht = document.getElementById("time-box") ? document.getElementById("time-box").offsetHeight : 225;
-    const mobile_ht = document.getElementById("time-box-mobile") ? document.getElementById("time-box-mobile").offsetHeight : 225;
-    const margin = Math.max(desktop_ht, mobile_ht, 225) + 25;
-    frame.style.marginBottom = margin + "px";
 }
 
 function hideElements(frame) {

--- a/static/js/modules/game/pagePreview.js
+++ b/static/js/modules/game/pagePreview.js
@@ -1,0 +1,42 @@
+var PagePreview = {
+
+	props: {
+		articlePreview: Object,
+		clientX: Number,
+		clientY: Number
+	},
+
+	methods: {
+		computePosition: function() {
+            const vh = window.innerHeight;
+            const vw = window.innerWidth;
+            const styleObject = {};
+
+            if (vw >= 768) {
+                if (this.clientX < vw / 2.0) {
+                    styleObject['left'] = `${this.clientX+10}px`;
+                } else {
+                    styleObject['right'] = `${vw-this.clientX+10}px`;
+                }
+                if (this.clientY < vh / 2.0) {
+                    styleObject['top'] = `${this.clientY+10}px`;
+                } else {
+                    styleObject['bottom'] = `${vh-this.clientY+10}px`;
+                }
+            } else {
+                styleObject['left'] = `${Math.floor((vw-360)/2)}px`;
+                styleObject['bottom'] = `${vh-this.clientY+25}px`;
+            }
+            return styleObject;
+        }
+	},
+
+	template: (`
+	<div class="tooltip-container" :style="computePosition()">
+        <img v-if="articlePreview.originalimage" :src="articlePreview.originalimage.source" />
+        <div v-html="articlePreview.extract_html"></div>
+    </div>
+	`)
+};
+
+export {PagePreview};

--- a/static/js/modules/game/pagePreview.js
+++ b/static/js/modules/game/pagePreview.js
@@ -33,7 +33,7 @@ var PagePreview = {
 
 	template: (`
 	<div class="tooltip-container" :style="computePosition()">
-        <img v-if="articlePreview.originalimage" :src="articlePreview.originalimage.source" />
+        <img v-if="articlePreview.thumbnail" :src="articlePreview.thumbnail.source" />
         <div v-html="articlePreview.extract_html"></div>
     </div>
 	`)

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -100,6 +100,7 @@ let app = new Vue({
         renderer: null,
         hover: false,
         loading: false,
+        blocker: false,
 
         clientX: 0,
         clientY: 0
@@ -173,15 +174,6 @@ let app = new Vue({
             fireworks();
         },
 
-        displayPreview: function() {
-            let html = "";
-            if ("originalimage" in this.articlePreview) {
-                html += '<img src="' + this.articlePreview["originalimage"]["source"] + '"/>';
-            }
-            html += '<div>' + this.articlePreview["extract_html"] + '</div>';
-            return html;
-        },
-
         computePosition: function() {
             const vh = window.innerHeight;
             const vw = window.innerWidth;
@@ -199,8 +191,8 @@ let app = new Vue({
                     styleObject['bottom'] = `${vh-this.clientY+10}px`;
                 }
             } else {
-                styleObject['left'] = '10px';
-                styleObject['bottom'] = `${document.getElementById("time-box-mobile").offsetHeight + 25}px`;
+                styleObject['left'] = `${Math.floor((vw-360)/2)}px`;
+                styleObject['bottom'] = `${vh-this.clientY+25}px`;
             }
             return styleObject;
         },

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -118,14 +118,12 @@ let app = new Vue({
 
         this.runId = await startRun(PROMPT_ID, LOBBY_ID);
 
-        this.renderer = new ArticleRenderer(document.getElementById("wikipedia-frame"), this.pageCallback, this.setupPreviews);
+        this.renderer = new ArticleRenderer(document.getElementById("wikipedia-frame"), this.pageCallback, this.mouseEnter, this.mouseLeave);
     },
 
 
     methods : {
-        async pageCallback(page, loadTime) {
-
-            // console.log("page callback")
+        pageCallback: function(page, loadTime) {
 
             this.loading = false;
             this.hover = false;
@@ -140,21 +138,9 @@ let app = new Vue({
 
             this.startTime += loadTime;
 
-            setMargin();
-
             //if the page's title matches that of the end article, finish the game, and submit the run
             if (page.replace("_", " ").toLowerCase() === this.endArticle.replace("_", " ").toLowerCase()) {
-
-                this.finished = true;
-
-                // Disable popup
-                window.onbeforeunload = null;
-
-                this.endTime = Date.now();
-
-                this.runId = await submitRun(PROMPT_ID, LOBBY_ID, this.runId, this.startTime, this.endTime, this.path);
-              
-                fireworks();
+                this.finish();
             }
 
         },
@@ -172,9 +158,19 @@ let app = new Vue({
             }, 50);
 
             await this.renderer.loadPage(this.startArticle);
+        },
 
-            this.setupPreviews();
-            await this.pageCallback(this.startArticle, Date.now() - this.startTime)
+        async finish() {
+            this.finished = true;
+
+            // Disable popup
+            window.onbeforeunload = null;
+
+            this.endTime = Date.now();
+
+            this.runId = await submitRun(PROMPT_ID, LOBBY_ID, this.runId, this.startTime, this.endTime, this.path);
+          
+            fireworks();
         },
 
         displayPreview: function() {
@@ -223,25 +219,10 @@ let app = new Vue({
             this.loading = false;
             this.hover = false;
             this.articlePreview = '';
-        },
-
-        setupPreviews: function() {
-            document.getElementById("wikipedia-frame").querySelectorAll("a").forEach(e => {
-                if (e.hasAttribute("href") && e.getAttribute("href").startsWith("/wiki/")) {
-                    e.addEventListener("mouseenter", this.mouseEnter);
-                    e.addEventListener("mouseleave", this.mouseLeave);
-                }
-            });
         }
 
     }
 })
-
-function setMargin() {
-    const element = document.getElementById("time-box");
-    let margin = (element.offsetHeight + 25) > 100 ? (element.offsetHeight + 25) : 100
-    document.getElementById("wikipedia-frame").style.marginBottom = margin +"px";
-}
 
 // Prevent accidental leaves
 window.onbeforeunload = function() {

--- a/static/js/replay.js
+++ b/static/js/replay.js
@@ -46,7 +46,7 @@ var app = new Vue({
         this.firstArticle  = this.path[0];
         this.lastArticle = this.path[this.path.length - 1];
 
-        this.renderer = new ArticleRenderer(document.getElementById(div_name), (_) => {});
+        this.renderer = new ArticleRenderer(document.getElementById(div_name), (_) => {}, null, null);
         await this.renderer.loadPage(this.path[0]);
     },
 

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -80,7 +80,7 @@ a:hover, a:hover * {
 .HUDwrapper-mobile {
     position:fixed;
     z-index: 1000;
-    width: 100%;
+    width: 100vw;
     bottom: 0;
     left:0;
     background-color: #F8F8F8;

--- a/static/stylesheets/play.css
+++ b/static/stylesheets/play.css
@@ -89,6 +89,17 @@
 }
 
 /* End article hover tooltip */
+.blocker {
+	position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    content: ' ';
+    background: rgba(0,0,0,.5);
+    z-index: 1000000;
+}
+
 .tooltip-container {
     width: 360px;
     font-size: 14px;

--- a/static/stylesheets/play.css
+++ b/static/stylesheets/play.css
@@ -173,6 +173,10 @@
     }
 }
 
+#wikipedia-frame {
+	margin-bottom: 40vh;
+}
+
 .HUDwrapper-mobile-inner-container {
     padding: 5px 10px;
     font-size: 14px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -79,7 +79,7 @@
             </div>
         </nav>
 
-        <div class="container-xxl">
+        <div class="container-xxl" style="overflow-x: hidden;">
             <div class="">
 
             {% block content %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -79,7 +79,7 @@
             </div>
         </nav>
 
-        <div class="container-xxl" style="overflow-x: hidden;">
+        <div class="container-xxl" style="overflow-x: auto;">
             <div class="">
 
             {% block content %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -79,7 +79,7 @@
             </div>
         </nav>
 
-        <div class="container-xxl" style="overflow-x: auto;">
+        <div class="container-xxl">
             <div class="">
 
             {% block content %}{% endblock %}

--- a/templates/marathon.html
+++ b/templates/marathon.html
@@ -30,7 +30,15 @@
                 <span v-show="!showStop"><br>Time Elapsed<br>[[parseInt(elapsed/60)]] mins</span>
             </div>
             <div class="col-lg-auto px-4">
-                Checkpoints<br><span v-html="formatActiveCheckpoints()"></span>
+                Checkpoints<br>
+                <ol style="padding-left: 1rem;">
+                    <li v-for="checkpoint in activeCheckpoints">
+                        <strong>[[checkpoint]] </strong>
+                        <small style="cursor: help;" :href="`/wiki/${checkpoint}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
+                            ⓘ
+                        </small>
+                    </li>
+                </ol>
             </div>
         </div>
         <div v-show="!showStop" class="row flex-row flex-nowrap justify-content-end py-2">
@@ -60,7 +68,15 @@
                     <br>Unique Articles Visited<br>[[numVisitedUnique]]
                 </div>
                 <div class="col-lg-auto px-4">
-                    Checkpoints<br><span v-html="formatActiveCheckpoints()"></span>
+                    Checkpoints<br>
+                    <ol style="padding-left: 1rem;">
+                        <li v-for="checkpoint in activeCheckpoints">
+                            <strong>[[checkpoint]] </strong>
+                            <small style="cursor: help;" :href="`/wiki/${checkpoint}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
+                                ⓘ
+                            </small>
+                        </li>
+                    </ol>
                 </div>
             </div>
             <div class="row flex-row flex-nowrap justify-content-end py-2">
@@ -79,6 +95,8 @@
 
     <marathon-help v-show="started && !finished && showHelp" v-cloak v-on:close-help="showHelp = !showHelp">
     </marathon-help>
+
+    <div v-if="loading && hover" v-html="displayPreview()" class="tooltip-container" :style="computePosition()"></div>
 
     <countdown-timer
         v-bind:start-article="startArticle"

--- a/templates/marathon.html
+++ b/templates/marathon.html
@@ -130,7 +130,7 @@
 
 
     <div v-show="started && !finished" id="main">
-        <div id="wikipedia-frame"></div>
+        <div id="wikipedia-frame" class="main-text"></div>
     </div>
 
 </div>

--- a/templates/marathon.html
+++ b/templates/marathon.html
@@ -72,7 +72,7 @@
                     <ol style="padding-left: 1rem;">
                         <li v-for="checkpoint in activeCheckpoints">
                             <strong>[[checkpoint]] </strong>
-                            <small style="cursor: help;" :href="`/wiki/${checkpoint}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
+                            <small style="cursor: help;" :href="`/wiki/${checkpoint}`" @click="(e) => { blocker=true; mouseEnter(e); }">
                                 ⓘ
                             </small>
                         </li>
@@ -96,7 +96,13 @@
     <marathon-help v-show="started && !finished && showHelp" v-cloak v-on:close-help="showHelp = !showHelp">
     </marathon-help>
 
-    <div v-if="loading && hover" v-html="displayPreview()" class="tooltip-container" :style="computePosition()"></div>
+    <div v-if="loading && hover">
+        <div v-if="blocker" class="blocker" @click="blocker=false; mouseLeave();"></div>
+        <div class="tooltip-container" :style="computePosition()">
+            <img v-if="articlePreview.originalimage" :src="`${articlePreview.originalimage.source}`" />
+            <div v-html="articlePreview.extract_html"></div>
+        </div>
+    </div>
 
     <countdown-timer
         v-bind:start-article="startArticle"

--- a/templates/marathon.html
+++ b/templates/marathon.html
@@ -72,7 +72,7 @@
                     <ol style="padding-left: 1rem;">
                         <li v-for="checkpoint in activeCheckpoints">
                             <strong>[[checkpoint]] </strong>
-                            <small style="cursor: help;" :href="`/wiki/${checkpoint}`" @click="(e) => { blocker=true; mouseEnter(e); }">
+                            <small style="cursor: help;" :href="`/wiki/${checkpoint}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
                                 ⓘ
                             </small>
                         </li>
@@ -96,12 +96,13 @@
     <marathon-help v-show="started && !finished && showHelp" v-cloak v-on:close-help="showHelp = !showHelp">
     </marathon-help>
 
-    <div v-if="loading && hover">
-        <div v-if="blocker" class="blocker" @click="blocker=false; mouseLeave();"></div>
-        <div class="tooltip-container" :style="computePosition()">
-            <img v-if="articlePreview.originalimage" :src="`${articlePreview.originalimage.source}`" />
-            <div v-html="articlePreview.extract_html"></div>
-        </div>
+    <div v-if="showPreview && articlePreview">
+        <div v-if="showPreviewBgUnderlay" class="blocker" @click="showPreviewBgUnderlay=false; mouseLeave();"></div>
+        <page-preview
+            :article-preview="articlePreview"
+            :client-x="clientX"
+            :client-y="clientY"
+        ></page-preview>
     </div>
 
     <countdown-timer

--- a/templates/play.html
+++ b/templates/play.html
@@ -17,24 +17,52 @@
 
 <div id="app">
 
-    <div v-show="started && !finished" id="time-box" class="HUDwrapper container">
-        <div class="row flex-row">
-            <div class="col-sm-auto text-nowrap px-4 py-2">
-                Start Article<br><strong>[[startArticle]]</strong>
-                <br>Current Article<br><strong>[[currentArticle]]</strong>
-            </div>
-            <div class="col-sm-auto text-nowrap px-4 py-2">
-                End Article<br><strong>[[endArticle]] </strong>
-                <small style="cursor: help;" :href="`/wiki/${endArticle}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
-                    ⓘ
-                </small>
-            </div>
-            <div class="col-sm-auto text-nowrap px-4 py-2">
-                Time Elapsed<br><strong>[[elapsed.toFixed(3)]] s</strong>
+    <div v-show="started && !finished">
+
+        <div class="show-on-desktop">
+            <div class="HUDwrapper container" id="time-box">
+                <div class="row flex-row">
+                    <div class="col-sm-auto text-nowrap px-4 py-2">
+                        Start Article<br><strong>[[startArticle]]</strong>
+                        <br>Current Article<br><strong>[[currentArticle]]</strong>
+                    </div>
+                    <div class="col-sm-auto text-nowrap px-4 py-2">
+                        End Article<br><strong>[[endArticle]] </strong>
+                        <small style="cursor: help;" :href="`/wiki/${endArticle}`" @click="(e) => { blocker=true; mouseEnter(e); }">
+                            ⓘ
+                        </small>
+                    </div>
+                    <div class="col-sm-auto text-nowrap px-4 py-2">
+                        Time Elapsed<br><strong>[[elapsed.toFixed(3)]] s</strong>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div v-if="loading && hover" v-html="displayPreview()" class="tooltip-container" :style="computePosition()"></div>
+        <div class="show-on-mobile">
+            <div class="HUDwrapper-mobile" id="time-box-mobile">
+                <div class="HUDwrapper-mobile-inner-container">
+                    Start Article: <strong>[[startArticle]]</strong>
+                    <br>
+                    End Article: <strong>[[endArticle]]</strong>
+                    <small style="cursor: help;" :href="`/wiki/${endArticle}`" @click="(e) => { blocker=true; mouseEnter(e); }">
+                        ⓘ
+                    </small>
+                    <br>
+                    Current Article: <strong>[[currentArticle]]</strong>
+                    <br>
+                    Time Elapsed: <strong>[[elapsed.toFixed(3)]] s</strong>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div v-if="loading && hover">
+        <div v-if="blocker" class="blocker" @click="blocker=false; mouseLeave();"></div>
+        <div class="tooltip-container" :style="computePosition()">
+            <img v-if="articlePreview.originalimage" :src="`${articlePreview.originalimage.source}`" />
+            <div v-html="articlePreview.extract_html"></div>
+        </div>
     </div>
 
     <countdown-timer id="time-box"

--- a/templates/play.html
+++ b/templates/play.html
@@ -25,7 +25,7 @@
             </div>
             <div class="col-sm-auto text-nowrap px-4 py-2">
                 End Article<br><strong>[[endArticle]] </strong>
-                <small style="cursor: default;" :href="`/wiki/${endArticle}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
+                <small style="cursor: help;" :href="`/wiki/${endArticle}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
                     ⓘ
                 </small>
             </div>

--- a/templates/play.html
+++ b/templates/play.html
@@ -28,7 +28,7 @@
                     </div>
                     <div class="col-sm-auto text-nowrap px-4 py-2">
                         End Article<br><strong>[[endArticle]] </strong>
-                        <small style="cursor: help;" :href="`/wiki/${endArticle}`" @click="(e) => { blocker=true; mouseEnter(e); }">
+                        <small style="cursor: help;" :href="`/wiki/${endArticle}`" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
                             ⓘ
                         </small>
                     </div>
@@ -45,7 +45,7 @@
                     Start Article: <strong>[[startArticle]]</strong>
                     <br>
                     End Article: <strong>[[endArticle]]</strong>
-                    <small style="cursor: help;" :href="`/wiki/${endArticle}`" @click="(e) => { blocker=true; mouseEnter(e); }">
+                    <small style="cursor: help;" :href="`/wiki/${endArticle}`" @click="(e) => { showPreviewBgUnderlay=true; mouseEnter(e); }">
                         ⓘ
                     </small>
                     <br>
@@ -57,12 +57,13 @@
         </div>
     </div>
 
-    <div v-if="loading && hover">
-        <div v-if="blocker" class="blocker" @click="blocker=false; mouseLeave();"></div>
-        <div class="tooltip-container" :style="computePosition()">
-            <img v-if="articlePreview.originalimage" :src="`${articlePreview.originalimage.source}`" />
-            <div v-html="articlePreview.extract_html"></div>
-        </div>
+    <div v-if="showPreview && articlePreview">
+        <div v-if="showPreviewBgUnderlay" class="blocker" @click="showPreviewBgUnderlay=false; mouseLeave();"></div>
+        <page-preview
+            :article-preview="articlePreview"
+            :client-x="clientX"
+            :client-y="clientY"
+        ></page-preview>
     </div>
 
     <countdown-timer id="time-box"


### PR DESCRIPTION
1. Moved preview pages logic to articleRenderer.js so it can be shared between sprint and marathon mode
2. Refactored articleRenderer.js and play.js: mainly stuff concerning callbacks, async functions, and bindings