### PR TITLE
fixed gap issue with streaks

### DIFF
--- a/test/test_streak.py
+++ b/test/test_streak.py
@@ -65,3 +65,19 @@ def test_streak_with_old_streak(cursor, user):
     res = streaks.get_current_streak(user_id)
     assert(res["streak"] == 4)
     assert(not res["done_today"])
+    
+    
+def test_streak_with_today_and_gap(cursor, user):
+    user_id = user["user_id"]
+    add_prompts(cursor, user_id, [0, 2, 3, 4, 10, 11, 12, 13])
+    res = streaks.get_current_streak(user_id)
+    assert(res["streak"] == 1)
+    assert(res["done_today"])
+    
+    
+def test_streak_without_today_and_gap(cursor, user):
+    user_id = user["user_id"]
+    add_prompts(cursor, user_id, [1, 3, 4, 10, 11, 12, 13])
+    res = streaks.get_current_streak(user_id)
+    assert(res["streak"] == 1)
+    assert(not res["done_today"])

--- a/wikispeedruns/streaks.py
+++ b/wikispeedruns/streaks.py
@@ -1,29 +1,48 @@
 from db import get_db
 from pymysql.cursors import DictCursor
+import json
 
 def get_current_streak(user_id):
 
     query = """
-    SELECT IF(MAX(run_date)=CURDATE(), 1, 0) as done_today, COUNT(*) AS streak FROM (
+    SELECT
+        DATEDIFF(CURDATE(), run_date) AS d
+    FROM (
         SELECT
-            run_date,
-            DATEDIFF(CURDATE(), run_date) AS Diff,
-            ROW_NUMBER() OVER(ORDER BY(run_date) DESC) AS rown
-        FROM (
-            SELECT
-                CAST(start_time AS DATE) as run_date
-            FROM sprint_runs
-            INNER JOIN sprint_prompts ON sprint_prompts.prompt_id = sprint_runs.prompt_id
-            WHERE
-                user_id=%s
-                AND sprint_runs.start_time BETWEEN sprint_prompts.active_start AND sprint_prompts.active_end
-                AND rated
-                AND end_time IS NOT NULL
-            GROUP BY run_date
-            ORDER BY run_date DESC )
-        as temp)
-    as temp2 WHERE Diff <= rown
+            CAST(start_time AS DATE) as run_date
+        FROM sprint_runs
+        INNER JOIN sprint_prompts ON sprint_prompts.prompt_id = sprint_runs.prompt_id
+        WHERE
+            user_id=%s
+            AND sprint_runs.start_time BETWEEN sprint_prompts.active_start AND sprint_prompts.active_end
+            AND rated
+            AND end_time IS NOT NULL
+        GROUP BY run_date
+        ORDER BY run_date DESC )
+    as date_diff
     """
     with get_db().cursor(cursor=DictCursor) as cursor:
-        result = cursor.execute(query, (user_id,))
-        return cursor.fetchone()
+        cursor.execute(query, (user_id,))
+        dates = cursor.fetchall()
+
+    dates = [x['d'] for x in dates]
+        
+    if len(dates) == 0:
+        today = 0
+        streak = 0
+    else:
+        if dates[0] == 0: today = 1
+        else: today = 0
+        
+        
+        if dates[0] == 0 or dates[0] == 1:
+            streak = 0
+            for i in range(len(dates)):
+                if dates[i] > i + dates[0]:
+                    break
+                streak += 1
+        else: streak = 0        
+        
+    res = {'done_today': today, 'streak': streak}
+    
+    return res


### PR DESCRIPTION
Counting of streaks no longer happens in the SQL query. The SQL query now returns a list of date differences for all days in which a player has played the active daily prompt. The processing now happens in python before it is passed to the front end