### PR TITLE
setup separate finish page

### DIFF
--- a/apis/lobbys.py
+++ b/apis/lobbys.py
@@ -157,3 +157,16 @@ def get_lobby_runs(lobby_id, prompt_id):
     runs = lobbys.get_lobby_runs(lobby_id, prompt_id)
 
     return jsonify(runs), 200
+
+
+# Run
+@lobby_api.get("/<int:lobby_id>/run/<int:run_id>")
+def get_lobby_run(lobby_id, run_id):
+    
+    print(lobby_id, run_id)
+    if not lobbys.check_membership(lobby_id, session):
+        return "You do not have access to this lobby", 401
+
+    runs = lobbys.get_lobby_run(lobby_id, run_id)
+
+    return jsonify(runs), 200

--- a/static/js/modules/game/finish.js
+++ b/static/js/modules/game/finish.js
@@ -1,81 +1,23 @@
+import { fetchJson } from "../fetch.js";
 
-var FinishPage = {
+async function getRun(runId) {
+    try {
+        const response = await fetchJson(`/api/runs/${runId}`, 'GET');
+        const body = await response.json();
+        return body;
+    } catch (e) {
+        console.log(e);
+    }
+}
 
-    props: [
-        "promptId",
-        "lobbyId",
-        "runId",
+async function getLobbyRun(lobbyId, runId) {
+    try {
+        const response = await fetchJson(`/api/lobbys/${lobbyId}/run/${runId}`, 'GET');
+        const body = await response.json();
+        return body;
+    } catch (e) {
+        console.log(e);
+    }
+}
 
-        "startArticle",
-        "endArticle",
-        "finalTime",
-        "path",
-
-        "loggedIn",
-    ],
-
-    methods: {
-        //copy sharable result
-        copyResults: function(event) {
-            let results = this.generateResults();
-            document.getElementById("custom-tooltip").style.display = "inline";
-            navigator.clipboard.writeText(results);
-            setTimeout(function() {
-                document.getElementById("custom-tooltip").style.display = "none";
-            }, 1500);
-        },
-
-
-        //redirect to the corresponding prompt page
-        finishPrompt: function (event) {
-            if (this.lobbyId) {
-                window.location.replace(`/lobby/${this.lobbyId}/prompt/${this.promptId}?run_id=${this.runId}`);
-            } else {
-                window.location.replace(`/prompt/${this.promptId}?run_id=${this.runId}`);
-            }
-        },
-
-        //go back to home page
-        home: function (event) {
-            if (this.lobbyId) {
-                window.location.replace(`/lobby/${this.lobbyId}`);
-            } else {
-                window.location.replace("/");
-            }
-        },
-
-
-        generateResults: function(event) {
-            return `Wiki Speedruns ${this.promptId}\n${this.startArticle}\n${this.path.length - 1} 🖱️\n${(this.finalTime) / 1000} ⏱️`
-        },
-
-    },
-
-    template: (`
-    <div v-cloak class="text-left">
-        <p><h4>You found it!</h4></p>
-        <p v-if="loggedIn">Your run was submitted to the leaderboard.</p>
-        <p v-else>You are not logged in, but your run has been saved locally. Log in to upload your runs to the leaderboard!</p>
-        <p><h4>Here's how you did:</h4></p>
-        <div class="card md">
-            <div class="card-body">
-                <p><h4><strong class="font-italic">"{{startArticle}}"</strong> to <strong class="font-italic">"{{endArticle}}"</strong></h4></p>
-                <p>Time: <strong>{{(finalTime / 1000).toFixed(3)}} </strong>Seconds</p>
-                <p>Number of links visited: <strong>{{path.length-1}}</strong></p>
-                <p>The path you took: <br>{{path}}</p>
-
-                <div v-if="!lobbyId" class="button-tooltip-container">
-                    <button @click="copyResults" class="share-btn btn-1 btn-1c"><i class="bi bi-share"></i> Share</button>
-                    <span id="custom-tooltip" ref="shareTooltip">Copied results to clipboard!</span>
-                </div>
-
-                <div><button @click="finishPrompt" class="btn btn-outline-secondary">See the leaderboard</button></div>
-                <br/>
-                <div><button @click="home" class="btn btn-outline-secondary">Return to home page</button></div>
-            </div>
-        </div>
-    </div>
-    `)
-};
-
-export {FinishPage};
+export { getRun, getLobbyRun};

--- a/static/js/modules/game/runs.js
+++ b/static/js/modules/game/runs.js
@@ -43,4 +43,4 @@ async function updateAnonymousRun(runId) {
 }
 
 
-export { startRun, submitRun, updateAnonymousRun };
+export { startRun, submitRun, updateAnonymousRun};

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -11,7 +11,7 @@ import { serverData } from "./modules/serverData.js";
 import { startRun, submitRun } from "./modules/game/runs.js";
 
 import { CountdownTimer } from "./modules/game/countdown.js";
-import { FinishPage } from "./modules/game/finish.js";
+//import { FinishPage } from "./modules/game/finish.js";
 import { ArticleRenderer } from "./modules/game/articleRenderer.js";
 import { PagePreview } from "./modules/game/pagePreview.js";
 
@@ -50,7 +50,7 @@ let app = new Vue({
     el: '#app',
     components: {
         'countdown-timer': CountdownTimer,
-        'finish-page': FinishPage,
+        //'finish-page': FinishPage,
         'page-preview': PagePreview
     },
     data: {
@@ -161,7 +161,13 @@ let app = new Vue({
                 //console.log(this.runId)
             }
 
-            fireworks();
+            //fireworks();
+            if (this.lobbyId == null) {
+                window.location.replace(`/finish?run_id=${this.runId}&played=true`);
+            } else {
+                window.location.replace(`/lobby/${this.lobbyId}/finish?run_id=${this.runId}&played=true`);
+            }
+            
         },
 
         showPreview: function(e) {

--- a/static/js/play_finish.js
+++ b/static/js/play_finish.js
@@ -1,0 +1,137 @@
+/* play.js is core of processing gameplay. This includes everything from retrieving information about a prompt,
+countdown to start, loading of each wikipedia page, parsing and filtering wikipedia links, processing game logic,
+and submitting runs.
+
+With the new Marathon game mode, many of these components are being reused with different game logic. So many of
+these components should be as modular/generic as possible.
+*/
+
+//JS module imports
+import { serverData } from "./modules/serverData.js";
+import { getRun, getLobbyRun } from "./modules/game/finish.js";
+
+import { basicCannon, fireworks, side } from "./modules/confetti.js";
+
+// Get lobby if a lobby_prompt
+const LOBBY_ID = serverData["lobby_id"] || null;
+const PLAYED = serverData["played"] || false;
+const RUN_ID = serverData["run_id"] || null;
+
+async function getPrompt(promptId, lobbyId=null) {
+    const url = (lobbyId === null) ? `/api/sprints/${promptId}` : `/api/lobbys/${lobbyId}/prompts/${promptId}`;
+    const response = await fetch(url);
+
+    if (response.status != 200) {
+        const error = await response.text();
+        alert(error);
+
+        // Prevent are you sure you want to leave prompt
+        window.onbeforeunload = null;
+        window.location.replace("/");   // TODO error page
+        return;
+    }
+
+    return await response.json();
+}
+
+
+//Vue container. This contains data, rendering flags, and functions tied to game logic and rendering. See play.html
+let app = new Vue({
+    delimiters: ['[[', ']]'],
+    el: '#app',
+    data: {
+        startArticle: "",    // For all game modes, this is the first article to load
+        endArticle: "",      // For sprint games. Reaching this article will trigger game finishing sequence
+        path: [],             // array to store the user's current path so far, submitted with run
+
+        promptId: null,        //Unique prompt id to load, this should be identical to 'const PROMPT_ID', but is mostly used for display
+
+        lobbyId: null,
+        runId: -1,          //unique ID for the current run. This gets populated upon start of run
+
+        startTime: null,     //For all game modes, the start time of run (mm elapsed since January 1, 1970)
+        endTime: null,       //For all game modes, the end time of run (mm elapsed since January 1, 1970)
+        finalTime: null,
+        loggedIn: false,
+
+        played: PLAYED
+    },
+
+    mounted: async function() {
+
+        this.loggedIn = "username" in serverData;
+
+        this.lobbyId = LOBBY_ID;
+
+        let run = null;
+        if (this.lobbyId != null) {
+            run = await getLobbyRun(this.lobbyId, RUN_ID); 
+        } else {
+            run = await getRun(RUN_ID);
+        }
+
+        this.promptId = run['prompt_id'];
+        const prompt = await getPrompt(this.promptId, LOBBY_ID);
+
+        this.startArticle = prompt["start"];
+        this.endArticle = prompt["end"];
+
+        var startDate = new Date(run['end_time']);
+        var endDate = new Date(run['start_time']);
+        this.finalTime = startDate.getTime() - endDate.getTime();
+
+        this.path = run['path'];
+
+        if (this.played) fireworks();
+
+    },
+
+
+    methods: {
+        //copy sharable result
+        copyResults: function(event) {
+            let results = this.generateResults();
+            document.getElementById("custom-tooltip").style.display = "inline";
+            document.getElementById("custom-tooltip-path").style.display = "none";
+            navigator.clipboard.writeText(results);
+            setTimeout(function() {
+                document.getElementById("custom-tooltip").style.display = "none";
+            }, 1500);
+        },
+
+        //copy sharable result
+        copyPath: function(event) {
+            let results = this.generatePath();
+            document.getElementById("custom-tooltip-path").style.display = "inline";
+            document.getElementById("custom-tooltip").style.display = "none";
+            navigator.clipboard.writeText(results);
+            setTimeout(function() {
+                document.getElementById("custom-tooltip-path").style.display = "none";
+            }, 1500);
+        },
+
+        //go back to home page
+        home: function (event) {
+            window.location.replace("/");
+        },
+
+        goToLobby: function (event) {
+            window.location.replace(`/lobby/${this.lobbyId}`);
+        },
+
+
+        generateResults: function(event) {
+            return `Wiki Speedruns ${this.promptId}\n${this.startArticle}\n${this.path.length - 1} 🖱️\n${(this.finalTime) / 1000} ⏱️`
+        },
+
+        generatePath: function(event) {
+            return String(this.path);
+        },
+
+        //redirect to the corresponding prompt page
+        goToLobbyLeaderboard: function (event) {
+            window.location.replace(`/lobby/${this.lobbyId}/prompt/${this.promptId}?run_id=${this.runId}`);
+        },
+    }
+})
+

--- a/static/js/prompt.js
+++ b/static/js/prompt.js
@@ -380,7 +380,6 @@ var app = new Vue({
 
             this.runs.forEach(el => {
                 let date = Date.parse(el.end_time)
-                console.log((now - date) / (1000 * 60 * 60 * 24))
             });
 
             if (!['1', '7', '30', '100'].includes(this.timeFilter)) return;
@@ -389,7 +388,6 @@ var app = new Vue({
 
             this.runs.forEach(el => {
                 let date = Date.parse(el.end_time)
-                console.log((now - date) / (1000 * 60 * 60 * 24))
                 if ((now - date) / (1000 * 60 * 60 * 24) < parseInt(this.timeFilter)){
                     output.push(el);
                 }

--- a/static/stylesheets/play.css
+++ b/static/stylesheets/play.css
@@ -8,9 +8,9 @@
 	color: inherit;
 	background: #0e83cd;
 	cursor: pointer;
-	padding: 15px 50px;
+	padding: 10px 30px;
 	display: inline-block;
-	margin: 20px 0px;
+	/*margin: 20px 0px;*/
 	text-transform: uppercase;
 	letter-spacing: 1px;
 	font-weight: 700;
@@ -74,12 +74,11 @@
 .button-tooltip-container {
     display: flex;
     align-items: center;
-    margin-top: 16px;
     min-height: 30px;
 
 }
 
-#custom-tooltip {
+#custom-tooltip, #custom-tooltip-path {
     display: none;
     margin-left: 40px;
     padding: 5px 12px;

--- a/templates/lobbys/lobby.html
+++ b/templates/lobbys/lobby.html
@@ -111,7 +111,7 @@ var app = new Vue({
     <p>[[lobbyInfo.desc]]</p>
 
     <h4>Invite Others: </h4>
-    <p> Link: [[window.location.href]]    </p>
+    <!--<p> Link: [[window.location.href]]    </p>-->
     <p> Passcode: [[lobbyInfo.passcode]]    </p>
 
 

--- a/templates/play.html
+++ b/templates/play.html
@@ -89,7 +89,7 @@
         <p v-else-if="promptRated">This is a practice attempt: your score will not appear on the public leaderboard</p>
     </countdown-timer>
 
-    <!-- TODO its a bit ugly passing all these in, should clean this up-->
+    <!-- REFACTORED OUT TO play_finish.html
     <finish-page
         v-bind:prompt-id="promptId"
         v-bind:lobby-id="lobbyId"
@@ -103,7 +103,7 @@
         v-bind:logged-in="loggedIn"
 
         v-show="finished"
-    ></finish-page>
+    ></finish-page>-->
 
     <div v-show="started && !finished" id="main">
         <div id="wikipedia-frame" class="mw-content-ltr sitedir-ltr ltr mw-body-content parsoid-body mediawiki mw-parser-output content"></div>

--- a/templates/play_finish.html
+++ b/templates/play_finish.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+
+{% block head %}
+
+<!-- play.js stylesheet -->
+<link rel="stylesheet" type= "text/css" href="{{url_for('static', filename='stylesheets/play.css')}}">
+<script type="module" src="{{url_for('static', filename='js/play_finish.js')}}"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
+
+<style>
+    [v-cloak] { display: none }
+</style>
+{% endblock %}
+
+{% block content %}
+
+<div id="app">
+<template v-cloak> <!--Top level v-cloak to hide stuff when loading vue-->
+    <div v-cloak class="text-left">
+        <div v-if="played">
+            <p><h4>You found it!</h4></p>
+            <p v-if="loggedIn">Your run was submitted to the leaderboard.</p>
+            <p v-else>You are not logged in, but your run has been saved locally. Log in to upload your runs to the leaderboard!</p>
+            <p><h4>Here's how you did:</h4></p>
+        </div>
+        <div class="card md">
+            <div class="card-body">
+                <p><h4><strong class="font-italic">"[[startArticle]]"</strong> to <strong class="font-italic">"[[endArticle]]"</strong></h4></p>
+                <p>Time: <strong>[[(finalTime / 1000).toFixed(3)]] </strong>Seconds</p>
+                <p>Number of links visited: <strong>[[path.length-1]]</strong></p>
+                <p>The path you took: <br>[[path]]</p>
+
+                <div class="row py-4" v-if="!lobbyId" >
+                    <div class="button-tooltip-container col-auto">
+                        <button @click="copyResults" class="share-btn btn-1 btn-1c"><i class="bi bi-share"></i> Share Run Summary</button>
+                        <span id="custom-tooltip" ref="shareTooltip">Copied results to clipboard!</span>
+                    </div>
+                    <div class="button-tooltip-container col-auto">
+                        <button @click="copyPath" class="share-btn btn-1 btn-1c"><i class="bi bi-share"></i> Share Path</button>
+                        <span id="custom-tooltip-path" ref="shareTooltip">Copied results to clipboard!</span>
+                    </div>
+                </div>
+
+                <div v-if="lobbyId" class="pb-3"><button @click="goToLobbyLeaderboard" class="btn btn-outline-secondary">See the lobby leaderboard</button></div>
+
+                <div v-if="lobbyId"><button @click="goToLobby" class="btn btn-outline-secondary">Return to lobby</button></div>
+                <div v-else><button @click="home" class="btn btn-outline-secondary">Return to home page</button></div>
+            </div>
+        </div>
+    </div>
+</template>
+</div>
+{% endblock %}

--- a/templates/play_finish.html
+++ b/templates/play_finish.html
@@ -31,21 +31,21 @@
                 <p>Number of links visited: <strong>[[path.length-1]]</strong></p>
                 <p>The path you took: <br>[[path]]</p>
 
-                <div class="row py-4" v-if="!lobbyId" >
-                    <div class="button-tooltip-container col-auto">
+                <div class="row py-0" v-if="!lobbyId" >
+                    <div class="button-tooltip-container col-auto py-2">
                         <button @click="copyResults" class="share-btn btn-1 btn-1c"><i class="bi bi-share"></i> Share Run Summary</button>
                         <span id="custom-tooltip" ref="shareTooltip">Copied results to clipboard!</span>
                     </div>
-                    <div class="button-tooltip-container col-auto">
+                    <div class="button-tooltip-container col-auto py-2">
                         <button @click="copyPath" class="share-btn btn-1 btn-1c"><i class="bi bi-share"></i> Share Path</button>
                         <span id="custom-tooltip-path" ref="shareTooltip">Copied results to clipboard!</span>
                     </div>
                 </div>
 
-                <div v-if="lobbyId" class="pb-3"><button @click="goToLobbyLeaderboard" class="btn btn-outline-secondary">See the lobby leaderboard</button></div>
+                <div v-if="lobbyId" class="py-3"><button @click="goToLobbyLeaderboard" class="btn btn-outline-secondary">See the lobby leaderboard</button></div>
 
                 <div v-if="lobbyId"><button @click="goToLobby" class="btn btn-outline-secondary">Return to lobby</button></div>
-                <div v-else><button @click="home" class="btn btn-outline-secondary">Return to home page</button></div>
+                <div v-else class="py-3"><button @click="home" class="btn btn-outline-secondary">Return to home page</button></div>
             </div>
         </div>
     </div>

--- a/views.py
+++ b/views.py
@@ -104,6 +104,29 @@ def get_tutorial_page():
 def get_sprint_play_page(id):
     return render_with_data('play.html', prompt_id=id)
 
+
+
+@views.route('/finish', methods=['GET'])
+def get_sprint_finish_page():
+    try:
+        run_id = int(request.args.get('run_id', -1))
+        played = request.args.get('played', False)
+        return render_with_data('play_finish.html', run_id=run_id, played=played)
+    except ValueError:
+        return "Page Not Found", 404
+    
+@views.route('/lobby/<int:lobby_id>/finish', methods=['GET'])
+def get_lobby_finish_page(lobby_id):
+    try:
+        run_id = int(request.args.get('run_id', -1))
+        played = request.args.get('played', False)
+        return render_with_data('play_finish.html', run_id=run_id, lobby_id=lobby_id, played=played)
+    except ValueError:
+        return "Page Not Found", 404
+
+
+
+
 @views.route('/prompt/<id>', methods=['GET'])
 def get_prompt_page(id):
     run_id = request.args.get('run_id', '')

--- a/wikispeedruns/lobbys.py
+++ b/wikispeedruns/lobbys.py
@@ -215,4 +215,28 @@ def get_lobby_runs(lobby_id: int, prompt_id: Optional[int]=None):
             run['path'] = json.loads(run['path'])
 
         return results
+    
+def get_lobby_run(lobby_id: int, run_id: int):
+    query = """
+        SELECT run_id, prompt_id, users.username, name, start_time, end_time, `path`,
+        TIMESTAMPDIFF(MICROSECOND, start_time, end_time) AS run_time
+        FROM lobby_runs
+        LEFT JOIN users ON users.user_id=lobby_runs.user_id
+        WHERE lobby_id=%(lobby_id)s AND run_id=%(run_id)s
+    """
+
+    query_args = {
+        "lobby_id": lobby_id,
+        "run_id": run_id
+    }
+
+    db = get_db()
+
+    with db.cursor(cursor=DictCursor) as cursor:
+        print(cursor.mogrify(query, query_args))
+        cursor.execute(query, query_args)
+        results = cursor.fetchone()
+        
+        results['path'] = json.loads(results['path'])
+        return results
 


### PR DESCRIPTION
Separated out the post-game summary as a separate page, main changes:
- Finish page is now at `/finish` or `lobby/<lobby_id>/finish`. Run id and lobby id (when applicable) are passed as args
- there is also an optional arg `played` passed into the finish page. If false (default), some text such as "you found it" and "your run was submitted to the leaderboard", as well as the confetti fireworks will not show. This is for when we want to link players back to this specific summary page later well after they've finished this run
- Global leaderboard button is removed. Lobby finish page still has the button to go to the lobby leaderboard
- Lobby finish page also does not have the share buttons (can be changed), and the "return to home" button is changed to "back to lobby"
- Added an API endpoint for retrieving only one lobby run based on runid and lobbyid

Other changes also included in this PR:
- added a path share button (text can be beautified)
- removed some leftover console outputs in some pages