### PR TITLE
Sprint hotfixes

### DIFF
--- a/static/js/modules/localStorage/localStorageSprint.js
+++ b/static/js/modules/localStorage/localStorageSprint.js
@@ -21,6 +21,12 @@ function submitLocalRun(promptId, runId, startTime, endTime, finished, path) {
         path: path
     };
 
+    let totalloadtime = -path[0]['loadTime'] + path[0]['timeReached'];
+    path.forEach(function (el) {
+        totalloadtime += el['loadTime']
+    });
+    data['play_time'] = (endTime - startTime) / 1000 - totalloadtime;
+
     const key = "WS-S-sprint-runs";
 
     let ls = getLocalStorageRuns(key);
@@ -59,5 +65,9 @@ function getLocalSprints() {
     return getLocalStorageRuns(key);
 }
 
-export { startLocalRun, submitLocalRun, uploadLocalSprints, getLocalSprints };
+function getLocalRun(run_id) {
+    return getLocalSprints()[run_id];
+}
+
+export { startLocalRun, submitLocalRun, uploadLocalSprints, getLocalSprints, getLocalRun };
 

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -178,7 +178,9 @@ let app = new Vue({
 
         async start() {
 
-            this.totalLoadTime += (Date.now() - this.startTime) / 1000;
+            let countdownTime = (Date.now() - this.startTime) / 1000;
+            this.totalLoadTime = countdownTime;
+            this.path[0]['timeReached'] = countdownTime;
 
             // set the timer update interval
             this.timerInterval = setInterval(() => {

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -112,6 +112,8 @@ let app = new Vue({
             console.log("Not logged in, uploading start of run to local storage")
         }
 
+        this.startTime = Date.now();
+
         this.renderer = new ArticleRenderer(document.getElementById("wikipedia-frame"), this.pageCallback, this.showPreview, this.hidePreview);
         await this.renderer.loadPage(this.startArticle);
 
@@ -175,8 +177,8 @@ let app = new Vue({
         },
 
         async start() {
-            // start timer
-            this.startTime = Date.now();
+
+            this.totalLoadTime += (Date.now() - this.startTime) / 1000;
 
             // set the timer update interval
             this.timerInterval = setInterval(() => {

--- a/static/js/play_finish.js
+++ b/static/js/play_finish.js
@@ -1,6 +1,7 @@
 //JS module imports
 import { serverData } from "./modules/serverData.js";
 import { getRun, getLobbyRun } from "./modules/game/finish.js";
+import { getLocalRun } from "./modules/localStorage/localStorageSprint.js"
 
 import { basicCannon, fireworks, side } from "./modules/confetti.js";
 
@@ -59,8 +60,10 @@ let app = new Vue({
         let run = null;
         if (this.lobbyId != null) {
             run = await getLobbyRun(this.lobbyId, RUN_ID);
-        } else {
+        } else if (this.loggedIn) {
             run = await getRun(RUN_ID);
+        } else if (!this.loggedIn) {
+            run = getLocalRun(RUN_ID);
         }
 
         this.promptId = run['prompt_id'];

--- a/wikispeedruns/runs.py
+++ b/wikispeedruns/runs.py
@@ -98,7 +98,7 @@ def _update_run(run_id: int, start_time: datetime, end_time: datetime,
     })
 
     duration = (end_time - start_time).total_seconds()
-    total_load_time = sum([entry.get('loadTime') for entry in path])
+    total_load_time = sum([entry.get('loadTime') for entry in path[1:]]) + path[0].get('timeReached')
     play_time = duration - total_load_time
 
     query_args = {


### PR DESCRIPTION
1. Fixed bug that caused bad request error when submitting the first run update (upon loading first page). The issue was that when we preload the article prior to the countdown, startTime was not initialized. Solution: moved startTime to be initialized before the first article is loaded, and store the duration from this startTime to when the countdown finishes (automatically or manually) as the 'timeReached' for the first article. This value is then subtracted from the final 'play_time'. This also fixed the bug that caused the first path element to have seconds since epoch timeReached values. 
2. anonymous users weren't able to view finished run results due to unauthorized error. We probably want to keep the restrictive access to the finish page, so solution was to instead read from locally stored runs if user is not logged in on the finish page (see user reported screenshot on discord). Locally stored sprint runs are now also stored with the 'play_time' value, computed at the end of a run. 