### PR TITLE
Lobby prompt deletion

### DIFF
--- a/apis/lobbys.py
+++ b/apis/lobbys.py
@@ -127,6 +127,20 @@ def get_lobby_prompts(lobby_id, prompt_id):
 
         return jsonify(prompts[0])
 
+@lobby_api.delete("/<int:lobby_id>/prompts")
+@check_user
+@check_request_json({"prompts": list})
+def delete_lobby_prompts(lobby_id):
+    user_id = session.get("user_id")
+    user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
+
+    if user_info is None or not user_info["owner"]:
+        return "Only the owner can delete prompts from this lobby", 401
+
+    prompts = request.json["prompts"]
+
+    lobbys.delete_lobby_prompts(lobby_id, prompts)
+    return "Prompts Deleted!", 200
 
 # Runs
 @lobby_api.get("/<int:lobby_id>/prompts/<int:prompt_id>/runs")

--- a/templates/lobbys/lobby.html
+++ b/templates/lobbys/lobby.html
@@ -133,6 +133,10 @@ var app = new Vue({
         },
 
         async deletePrompts() {
+            if (!confirm("Are you sure you want to delete the selected prompts and their runs?")) {
+               return; 
+            }
+
             const resp = await fetchJson(`/api/lobbys/${LOBBY_ID}/prompts`, "DELETE", {
                 "prompts": Array.from(this.selectedPrompts),
             }); 
@@ -239,7 +243,7 @@ var app = new Vue({
                     </tr>
                 </tbody>
             </table>
-            <input v-if="editPrompts" @click="deletePrompts" class="btn btn-danger" value="Delete Selected">
+            <input v-if="editPrompts" href="javascript:;" @click="deletePrompts" class="btn btn-danger" value="Delete Selected">
         </div>
     </div>
 

--- a/templates/lobbys/lobby.html
+++ b/templates/lobbys/lobby.html
@@ -11,6 +11,10 @@
 
 }
 
+.prompt-header h3 { 
+  display: inline;
+}
+
 #custom-tooltip {
     display: none;
     margin-left: 10px;
@@ -49,6 +53,9 @@ var app = new Vue({
                 "owner": null
             }
         },
+
+        editPrompts: false,
+        selectedPrompts: new Set(),
     },
 
 
@@ -70,6 +77,18 @@ var app = new Vue({
             setTimeout(function() {
                 document.getElementById("custom-tooltip").style.display = "none";
             }, 1500);
+        },
+
+        selectPrompt(prompt_id) {
+            if (this.selectedPrompts.has(prompt_id)) {
+                this.selectedPrompts.delete(prompt_id);
+            } else {
+                this.selectedPrompts.add(prompt_id);
+            }
+        },
+
+        clearSelectedPrompts() {
+            this.selectedPrompts.clear();
         },
 
         async getLobbyInfo() {
@@ -109,6 +128,16 @@ var app = new Vue({
                 "start": start,
                 "end": end
             });
+
+            this.getPrompts();
+        },
+
+        async deletePrompts() {
+            console.log('deleting...')
+
+            const resp = await fetchJson(`/api/lobbys/${LOBBY_ID}/prompts`, "DELETE", {
+                "prompts": this.selectedPrompts,
+            }); 
 
             this.getPrompts();
         }
@@ -178,8 +207,13 @@ var app = new Vue({
     </template>
 
 
-    <h3> Prompts </h3>
-
+    <div class="prompt-header">
+        <h3> Prompts </h3>
+        <template v-if="lobbyInfo.user.owner">
+            <a v-on:click="editPrompts = !editPrompts">(Edit)</a>
+        </template>
+    </div>
+    
     <div class="card">
         <div class="card-body">
             <table class="table table-hover">
@@ -199,9 +233,13 @@ var app = new Vue({
                         <td>[[prompt.end]]</td>
 
                         <td><a v-bind:href="'/lobby/' + lobbyInfo.lobby_id + '/prompt/' + prompt.prompt_id">Results</a></td>
+                        <td v-if="editPrompts">
+                            <input type="checkbox" @click="selectPrompt(prompt.prompt_id)">
+                        </td>
                     </tr>
                 </tbody>
             </table>
+            <input v-if="editPrompts" @click="deletePrompts" class="btn btn-danger" value="Delete Selected">
         </div>
     </div>
 

--- a/templates/lobbys/lobby.html
+++ b/templates/lobbys/lobby.html
@@ -133,12 +133,12 @@ var app = new Vue({
         },
 
         async deletePrompts() {
-            console.log('deleting...')
-
             const resp = await fetchJson(`/api/lobbys/${LOBBY_ID}/prompts`, "DELETE", {
-                "prompts": this.selectedPrompts,
+                "prompts": Array.from(this.selectedPrompts),
             }); 
 
+            this.editPrompts = false;
+            this.clearSelectedPrompts();
             this.getPrompts();
         }
     }

--- a/wikispeedruns/lobbys.py
+++ b/wikispeedruns/lobbys.py
@@ -119,6 +119,25 @@ def get_lobby_prompts(lobby_id: int, prompt_id: Optional[int]=None ) -> List[Lob
         cursor.execute(query, query_args)
         return cursor.fetchall()
 
+def delete_lobby_prompts(lobby_id: int, prompts: List[int]) -> bool:
+    tables = ['lobby_runs', 'lobby_prompts']
+
+    query_start = 'DELETE FROM'
+    query_body = 'WHERE lobby_id=%(lobby_id)s AND prompt_id IN %(prompts)s'
+    
+    query_args = {
+        "lobby_id": lobby_id,
+        "prompts": tuple(prompts)
+    }
+    
+    db = get_db()
+    with db.cursor() as cursor:
+        for table in tables:
+            query = f'{query_start} {table} {query_body}'
+            cursor.execute(query, query_args)
+        db.commit()
+
+        return True
 
 # Lobby user management
 


### PR DESCRIPTION
Adds an edit mode for lobby owners
* Shows/hides checkboxes next to prompts
   * Can be used for other things in the future wrt prompt management
* Delete button to delete selected prompts
   * Pop-up alert added for confirmation
   * Backend checks that user session is owner of lobby

Deletion nukes the prompts and their runs from our database
Closes #353 

Test:

https://user-images.githubusercontent.com/17424008/172041671-7321fb79-d15c-4ea4-8851-c2d8470594f2.mov

View from non-owner (no edit button is shown):
<img width="1727" alt="Screen Shot 2022-06-05 at 1 08 46 AM" src="https://user-images.githubusercontent.com/17424008/172041709-359d9c6c-7ea4-41ee-a513-f818eabc3052.png">

