### PR TITLE
Pause timer on page load

### DIFF
--- a/static/js/modules/game/articleRenderer.js
+++ b/static/js/modules/game/articleRenderer.js
@@ -5,15 +5,20 @@ export class ArticleRenderer {
     /* frame: DOM element (i.e. through getElementById) to render article in
      * pageCallback: Called upon loading an article, should expect new page and load time
      */
-    constructor(frame, pageCallback, mouseEnter, mouseLeave) {
+    constructor(frame, pageCallback, mouseEnter, mouseLeave, loadCallback=null) {
         this.frame = frame;
         this.pageCallback = pageCallback;
+        this.loadCallback = loadCallback;
         this.mouseEnter = mouseEnter;
         this.mouseLeave = mouseLeave;
     }
 
     async loadPage(page) {
         try {
+            if (this.loadCallback) {
+                this.loadCallback();
+            }
+            
             const isMobile = window.screen.width < 768;
             const startTime = Date.now();
             const body = await getArticle(page, isMobile);


### PR DESCRIPTION
Purely frontend changes, pause/start a timer instead of subtracting the load time (which confusingly incremented during page load)
* Lines up similarly with backend times (not that it lined up exactly before)

Test:

https://user-images.githubusercontent.com/17424008/172046840-b502e2d0-180c-4b79-a589-e30d873612a8.mp4


