### PR TITLE
Fix race condition and incorrect timebox time

### DIFF
--- a/static/js/play.js
+++ b/static/js/play.js
@@ -190,9 +190,10 @@ let app = new Vue({
         },
 
         async start() {
+            this.countdownTime = (Date.now() - this.startTime) / 1000;
+            
             // Set first page timeReached if start() called after first page is loaded
             if (this.path.length == 1) {
-                this.countdownTime = (Date.now() - this.startTime) / 1000;
                 this.path[0]['timeReached'] = this.countdownTime;
             }
 


### PR DESCRIPTION
* Race condition between start() and first page callback
* Zero out timer on starting play