### PR TITLE
added back the lobby text at top of homepage

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -56,6 +56,18 @@
         <p>First time? Play the <a href="/play/tutorial">tutorial</a>!</p>
 
         <p>Try our new prompt generator <a href="/generator">here</a>!</p>
+
+        <template v-cloak>
+            <p v-if="loggedIn === true && lobbies.length > 0">
+                See your active lobbies <a href="#user-lobbies">here</a> or <a href="/lobby/create">create a new private lobby</a>.
+            </p>
+            <p v-if="loggedIn === true && lobbies.length == 0">
+                Playing with friends? Create a new private lobby <a href="/lobby/create">here</a>!
+            </p>
+            <p v-if="loggedIn === false">
+                <a href="/login">Log in</a>/<a href="/register">Register</a> to create a new private lobby and play with your friends!
+            </p>
+        </template>
     </div>
 
     <hr class="my-4">


### PR DESCRIPTION
Just added the text about lobbies that we used to have at the top of the homepage back

I feel that since lobbies is probably one of our most appealing features, we should try to emphasize that more, especially for users who wont be bothered to scroll all the way down. 

We can discuss this more on Tues if it helps