### PR TITLE
Per-prompt Stats on Leaderboards

### DIFF
--- a/apis/leaderboard_api.py
+++ b/apis/leaderboard_api.py
@@ -64,22 +64,26 @@ def get_lobby_leaderboard(lobby_id, prompt_id, run_id):
     return jsonify(resp), 200
 
 
-@leaderboard_api.post('/sprints/<int:prompt_id>/stats')
+@leaderboard_api.post('/sprints/<int:prompt_id>/stats', defaults={'run_id' : None})
+@leaderboard_api.post('/sprints/<int:prompt_id>/stats/<int:run_id>')
 @check_request_json(LEADERBOARD_JSON)
-def get_sprint_leaderboard_stats(prompt_id):
+def get_sprint_leaderboard_stats(prompt_id, run_id):
     resp = leaderboards.get_leaderboard_stats(
         prompt_id=prompt_id,
+        run_id=run_id,
         **request.json
     )
 
     return jsonify(resp), 200
 
-@leaderboard_api.post('/lobbys/<int:lobby_id>/prompts/<int:prompt_id>/stats')
+@leaderboard_api.post('/lobbys/<int:lobby_id>/prompts/<int:prompt_id>/stats', defaults={'run_id' : None})
+@leaderboard_api.post('/lobbys/<int:lobby_id>/prompts/<int:prompt_id>/stats/<int:run_id>')
 @check_request_json(LEADERBOARD_JSON)
-def get_lobby_leaderboard_stats(lobby_id, prompt_id):
+def get_lobby_leaderboard_stats(lobby_id, prompt_id, run_id):
     resp = leaderboards.get_leaderboard_stats(
         lobby_id=lobby_id,
         prompt_id=prompt_id,
+        run_id=run_id,
         **request.json
     )
 

--- a/apis/leaderboard_api.py
+++ b/apis/leaderboard_api.py
@@ -63,3 +63,24 @@ def get_lobby_leaderboard(lobby_id, prompt_id, run_id):
     resp["prompt"] = prompts[0]
     return jsonify(resp), 200
 
+
+@leaderboard_api.post('/sprints/<int:prompt_id>/stats')
+@check_request_json(LEADERBOARD_JSON)
+def get_sprint_leaderboard_stats(prompt_id):
+    resp = leaderboards.get_leaderboard_stats(
+        prompt_id=prompt_id,
+        **request.json
+    )
+
+    return jsonify(resp), 200
+
+@leaderboard_api.post('/lobbys/<int:lobby_id>/prompts/<int:prompt_id>/stats')
+@check_request_json(LEADERBOARD_JSON)
+def get_lobby_leaderboard_stats(lobby_id, prompt_id):
+    resp = leaderboards.get_leaderboard_stats(
+        lobby_id=lobby_id,
+        prompt_id=prompt_id,
+        **request.json
+    )
+
+    return jsonify(resp), 200

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -1,5 +1,6 @@
 import { serverData } from "./modules/serverData.js"
 import { fetchJson } from "./modules/fetch.js"
+import { round } from "./modules/wikipediaAPI/util.js";
 
 
 import { pathArrowFilter } from "./modules/game/filters.js";
@@ -280,7 +281,11 @@ var app = new Vue({
 
         preset: "",
         
+        // Leaderboard Stats
         stats: {},
+        finishPct: 0,
+        avgClicks: 0,
+        avgTime: 0,
     },
 
     computed: {
@@ -401,8 +406,19 @@ var app = new Vue({
             }
         }
 
+        // Prompt Stats
+        let statsEndpoint = this.lobbyId === null
+        ? `/api/sprints/${this.promptId}/stats`
+        : `/api/lobbys/${this.lobbyId}/prompts/${this.promptId}/stats`;
 
+        var response = await fetchJson(statsEndpoint, "POST", {
+            ...args
+        });
+        let statJson = await response.json();
 
+        // TODO: Properly set data after navigation 
+        this.stats.finish_pct = statJson['finish_pct'];
+        this.finishPct = round(statJson['finish_pct'], 2);
 
         this.genGraph();
     }

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -279,6 +279,8 @@ var app = new Vue({
         offset: 0,
 
         preset: "",
+        
+        stats: {},
     },
 
     computed: {

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -396,7 +396,7 @@ var app = new Vue({
         if (currRunIndex !== -1) {
             this.currentRun = this.runs[currRunIndex];
 
-            // check if current run does not fall within range, remove and set positon if so
+            // check if current run does not fall within range, remove and set position if so
             if (this.currentRun['rank'] - 1 < this.offset) {
                 this.currentRunPosition = -1 ;
                 this.runs.splice(currRunIndex, 1);

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -1,7 +1,5 @@
 import { serverData } from "./modules/serverData.js"
 import { fetchJson } from "./modules/fetch.js"
-import { round } from "./modules/wikipediaAPI/util.js";
-
 
 import { pathArrowFilter } from "./modules/game/filters.js";
 
@@ -282,10 +280,11 @@ var app = new Vue({
         preset: "",
         
         // Leaderboard Stats
-        stats: {},
-        finishPct: 0,
-        avgClicks: 0,
-        avgTime: 0,
+        stats: {
+            finishPct: 0,
+            avgClicks: 0,
+            avgTime: 0,
+        },
     },
 
     computed: {
@@ -421,10 +420,9 @@ var app = new Vue({
         let statJson = await response.json();
 
         // TODO: Properly set data after navigation 
-        this.stats.finish_pct = statJson['finish_pct'];
-        this.finishPct = round(statJson['finish_pct'], 2);
-        this.avgClicks = round(statJson['avg_path_len'], 2);
-        this.avgTime = round(statJson['avg_play_time'], 2);
+        this.stats.finishPct = parseFloat(statJson['finish_pct']).toFixed(2);
+        this.stats.avgClicks = parseFloat(statJson['avg_path_len']).toFixed(2);
+        this.stats.avgTime = parseFloat(statJson['avg_play_time']).toFixed(2);
 
         this.genGraph();
     }

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -411,6 +411,10 @@ var app = new Vue({
         ? `/api/sprints/${this.promptId}/stats`
         : `/api/lobbys/${this.lobbyId}/prompts/${this.promptId}/stats`;
 
+        if (this.runId !== -1) {
+            statsEndpoint += `/${this.runId}`;
+        }
+
         var response = await fetchJson(statsEndpoint, "POST", {
             ...args
         });
@@ -419,6 +423,8 @@ var app = new Vue({
         // TODO: Properly set data after navigation 
         this.stats.finish_pct = statJson['finish_pct'];
         this.finishPct = round(statJson['finish_pct'], 2);
+        this.avgClicks = round(statJson['avg_path_len'], 2);
+        this.avgTime = round(statJson['avg_play_time'], 2);
 
         this.genGraph();
     }

--- a/static/js/modules/wikipediaAPI/util.js
+++ b/static/js/modules/wikipediaAPI/util.js
@@ -71,4 +71,8 @@ async function getArticleSummary(page) {
     return body
 }
 
-export { getArticle, getArticleTitle, getArticleSummary, articleCheck };
+function round(value, decimals) {
+    return Number(Math.round(value+'e'+decimals)+'e-'+decimals);
+}   
+
+export { getArticle, getArticleTitle, getArticleSummary, articleCheck, round };

--- a/static/js/modules/wikipediaAPI/util.js
+++ b/static/js/modules/wikipediaAPI/util.js
@@ -71,8 +71,4 @@ async function getArticleSummary(page) {
     return body
 }
 
-function round(value, decimals) {
-    return Number(Math.round(value+'e'+decimals)+'e-'+decimals);
-}   
-
-export { getArticle, getArticleTitle, getArticleSummary, articleCheck, round };
+export { getArticle, getArticleTitle, getArticleSummary, articleCheck };

--- a/static/stylesheets/leaderboard.css
+++ b/static/stylesheets/leaderboard.css
@@ -1,5 +1,5 @@
 .progress {
-	width:50%;
+	width: 50%;
 	margin-top: .2rem;
 }
 
@@ -10,15 +10,16 @@
 
 .stat {
 	font-size:large;
-	font-weight: bold;
+	font-weight: 500;
 	margin-top: -.25rem;
 }
 
+p.mobile { display: none }
+
 /* Mobile */
 @media (max-width: 768px) {                  
-	.hide-if-mobile {
-	   display: none;
-	}
+    p.mobile { display: block }
+    p.desktop { display: none }
 
 	.progress {
 		width: 100%;

--- a/static/stylesheets/leaderboard.css
+++ b/static/stylesheets/leaderboard.css
@@ -1,0 +1,15 @@
+.progress {
+	margin-top: .2rem;
+}
+
+.progress-label {
+	float: left;
+	margin-right: 1em;
+}
+
+/* Mobile */
+@media (max-width: 768px) {                  
+	.hide-if-mobile {
+	   display: none;
+	}
+ }

--- a/static/stylesheets/leaderboard.css
+++ b/static/stylesheets/leaderboard.css
@@ -1,4 +1,5 @@
 .progress {
+	width:50%;
 	margin-top: .2rem;
 }
 
@@ -7,9 +8,25 @@
 	margin-right: 1em;
 }
 
+.stat {
+	font-size:large;
+	font-weight: bold;
+	margin-top: -.25rem;
+}
+
 /* Mobile */
 @media (max-width: 768px) {                  
 	.hide-if-mobile {
 	   display: none;
+	}
+
+	.progress {
+		width: 100%;
+	}
+
+	.progress-label,
+	.stat {
+		margin-bottom: 0;
+		margin-top:1rem;
 	}
  }

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -10,6 +10,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js"></script>
 
 <script defer type="module" src="{{url_for('static', filename='js/leaderboard.js') }}"></script>
+
+<link rel= "stylesheet" type= "text/css" href="{{url_for('static', filename='stylesheets/leaderboard.css')}}">
 {% endblock %}
 
 {% block content %}
@@ -29,15 +31,47 @@
         </div>
 
         <div class="card">
-            <div class="card-header pt-3">
+            <div class="row">
+                <div class="col-8" style="padding-right:0">
+                    <div class="card-header pt-3" style="height: 8rem;">
 
-                <h4>Prompt [[prompt.prompt_id || ""]]</h4>
+                        <h4>Prompt [[prompt.prompt_id || ""]]</h4>
 
-                <h6 v-if="available">
-                    <strong>[[prompt.start]]</strong> to <strong v-if="runs.length > 0">[[prompt.end]]</strong><strong v-else>...</strong>
-                </h6>
+                        <h6 v-if="available">
+                            <strong>[[prompt.start]]</strong> to <strong v-if="runs.length > 0">[[prompt.end]]</strong><strong v-else>...</strong>
+                        </h6>
 
-                <p>[[numRuns]] total runs</p>
+
+                        <p>[[numRuns]] total runs</p>
+                    </div>
+                </div>  
+
+                <div class="col" style="padding-left:0">
+                    <div class="card-header pt-3" style="height: 8rem;">   
+                        <div class="row mb-1">
+                            <div class="col">
+                            <p class="text-muted small progress-label hide-if-mobile">Success Rate:</p>
+                            <div class="progress w-50">
+                                <div class="progress-bar bg-success" role="progressbar" style="width: 25%" :aria-valuenow="numRuns" aria-valuemin="0" aria-valuemax="100">
+                                    [[stats]]%
+                                </div>
+                            </div>
+                            </div>
+                        </div>
+
+                        <div class="row mb-1">
+                            <div class="col">
+                            <p class="text-muted small progress-label hide-if-mobile">Avg. # Clicks:</p>
+                            </div>
+                        </div>
+
+                        <div class="row mb-1">
+                            <div class="col">
+                            <p class="text-muted small progress-label hide-if-mobile">Avg. Completion Time:</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="card-body">

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -48,10 +48,10 @@
 
                 <div class="col" style="padding-left:0">
                     <div class="card-header pt-3" style="height: 8rem;">   
-                        <div class="row mb-1">
+                        <div class="row">
                             <div class="col">
                             <p class="text-muted small progress-label hide-if-mobile">Success Rate:</p>
-                            <div class="progress w-50">
+                            <div class="progress">
                                 <div class="progress-bar bg-success" role="progressbar" style="width: 25%" :aria-valuenow="numRuns" aria-valuemin="0" aria-valuemax="100">
                                     [[stats]]%
                                 </div>
@@ -59,15 +59,17 @@
                             </div>
                         </div>
 
-                        <div class="row mb-1">
+                        <div class="row"> 
                             <div class="col">
-                            <p class="text-muted small progress-label hide-if-mobile">Avg. # Clicks:</p>
+                            <p class="text-muted small progress-label hide-if-mobile">Avg. # Clicks: </p>
+                            <p class="stat text-dark">[[stats]]</p>
                             </div>
                         </div>
 
-                        <div class="row mb-1">
+                        <div class="row">
                             <div class="col">
                             <p class="text-muted small progress-label hide-if-mobile">Avg. Completion Time:</p>
+                            <p class="stat text-dark">[[stats]]</p>
                             </div>
                         </div>
                     </div>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -50,7 +50,7 @@
                     <div class="card-header pt-3" style="height: 8rem;">   
                         <div class="row">
                             <div class="col">
-                            <p class="text-muted small progress-label hide-if-mobile">Success Rate:</p>
+                            <p class="text-muted small progress-label desktop">Success Rate:</p>
 
                             <!-- TODO: Add hover -->
                             <!-- TODO: Properly fetch data after navigation  -->
@@ -64,15 +64,17 @@
 
                         <div class="row"> 
                             <div class="col">
-                            <p class="text-muted small progress-label hide-if-mobile">Avg. # Clicks: </p>
+                            <p class="text-muted small progress-label desktop">Avg. # Clicks: </p>
+                            <p class="progress-label mobile">🖱️ </p>
                             <p class="stat text-dark">[[avgClicks]]</p>
                             </div>
                         </div>
 
                         <div class="row">
                             <div class="col">
-                            <p class="text-muted small progress-label hide-if-mobile">Avg. Completion Time:</p>
-                            <p class="stat text-dark">[[avgTime]]</p>
+                            <p class="text-muted small progress-label desktop">Avg. Completion Time:</p>
+                            <p class="progress-label mobile">⏱️ </p>
+                            <p class="stat text-dark">[[avgTime]]s</p>
                             </div>
                         </div>
                     </div>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -51,9 +51,12 @@
                         <div class="row">
                             <div class="col">
                             <p class="text-muted small progress-label hide-if-mobile">Success Rate:</p>
+
+                            <!-- TODO: Add hover -->
+                            <!-- TODO: Properly fetch data after navigation  -->
                             <div class="progress">
-                                <div class="progress-bar bg-success" role="progressbar" style="width: 25%" :aria-valuenow="numRuns" aria-valuemin="0" aria-valuemax="100">
-                                    [[stats]]%
+                                <div class="progress-bar bg-success" role="progressbar" :style="{ width: finishPct + '%' }" :aria-valuenow="finishPct" aria-valuemin="0" aria-valuemax="100">
+                                    [[finishPct]]%
                                 </div>
                             </div>
                             </div>
@@ -62,14 +65,14 @@
                         <div class="row"> 
                             <div class="col">
                             <p class="text-muted small progress-label hide-if-mobile">Avg. # Clicks: </p>
-                            <p class="stat text-dark">[[stats]]</p>
+                            <p class="stat text-dark">[[avgClicks]]</p>
                             </div>
                         </div>
 
                         <div class="row">
                             <div class="col">
                             <p class="text-muted small progress-label hide-if-mobile">Avg. Completion Time:</p>
-                            <p class="stat text-dark">[[stats]]</p>
+                            <p class="stat text-dark">[[avgTime]]</p>
                             </div>
                         </div>
                     </div>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -50,7 +50,7 @@
                     <div class="card-header pt-3" style="height: 8rem;">   
                         <div class="row">
                             <div class="col">
-                            <p class="text-muted small progress-label desktop">Success Rate:</p>
+                            <p class="text-muted small progress-label desktop">Completion Rate:</p>
 
                             <!-- TODO: Add hover -->
                             <!-- TODO: Properly fetch data after navigation  -->

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -55,8 +55,8 @@
                             <!-- TODO: Add hover -->
                             <!-- TODO: Properly fetch data after navigation  -->
                             <div class="progress">
-                                <div class="progress-bar bg-success" role="progressbar" :style="{ width: finishPct + '%' }" :aria-valuenow="finishPct" aria-valuemin="0" aria-valuemax="100">
-                                    [[finishPct]]%
+                                <div class="progress-bar bg-success" role="progressbar" :style="{ width: stats.finishPct + '%' }" :aria-valuenow="stats.finishPct" aria-valuemin="0" aria-valuemax="100">
+                                    [[stats.finishPct]]%
                                 </div>
                             </div>
                             </div>
@@ -66,7 +66,7 @@
                             <div class="col">
                             <p class="text-muted small progress-label desktop">Avg. # Clicks: </p>
                             <p class="progress-label mobile">🖱️ </p>
-                            <p class="stat text-dark">[[avgClicks]]</p>
+                            <p class="stat text-dark">[[stats.avgClicks]]</p>
                             </div>
                         </div>
 
@@ -74,7 +74,7 @@
                             <div class="col">
                             <p class="text-muted small progress-label desktop">Avg. Completion Time:</p>
                             <p class="progress-label mobile">⏱️ </p>
-                            <p class="stat text-dark">[[avgTime]]s</p>
+                            <p class="stat text-dark">[[stats.avgTime]]s</p>
                             </div>
                         </div>
                     </div>

--- a/wikispeedruns/leaderboards.py
+++ b/wikispeedruns/leaderboards.py
@@ -272,7 +272,6 @@ def get_leaderboard_stats(
     lb_query = get_leaderboard_runs(prompt_id, lobby_id, run_id, limit=None, offset=0, query_only=True, **kwargs)
     response = {}
 
-    # Success Rate
     query = f'''
     WITH data AS (
         {lb_query['query']}
@@ -293,10 +292,6 @@ def get_leaderboard_stats(
         results = cursor.fetchall()
 
         return results[0]
-
-    # Avg. # of Clicks
-
-    # Avg. Completion Time
 
 '''
 if __name__ == "__main__":

--- a/wikispeedruns/leaderboards.py
+++ b/wikispeedruns/leaderboards.py
@@ -5,7 +5,7 @@ import json
 
 
 # For local testing you can comment out this get_db import and use the below code to manually connect to the db
-# and run the file directly. Preferabley, you should use unit tests (which I have yet to write)
+# and run the file directly. Preferably, you should use unit tests (which I have yet to write)
 from db import get_db
 '''
 def get_db():
@@ -25,7 +25,6 @@ def get_db():
     return conn
 '''
 
-
 # Get runs for a prompt, with lots of options (described below)
 # See bottom of file for example usage
 def get_leaderboard_runs(
@@ -33,7 +32,7 @@ def get_leaderboard_runs(
     prompt_id: int,
     lobby_id: Optional[int] = None,
 
-    run_id = None, # inlcude the current run
+    run_id = None, # include the current run
 
     ########### global filtering ###########
     show_unfinished: bool = False,
@@ -70,6 +69,9 @@ def get_leaderboard_runs(
     ########### pagination ###########
     offset: int = 0,
     limit: Optional[int] = 20,
+
+    # only return resulting query
+    query_only: bool = False,
 ):
     # conditions is a set of templated SQL expressions to include in the final WHERE clause
     # query_args are the user inputs that will be filled by cursor.execute
@@ -114,7 +116,7 @@ def get_leaderboard_runs(
     # Filter by time
     if played_before is not None:
         if lobby_id is not None:
-            return NotImplementedError("played_before not implemneted for lobby_promts")
+            return NotImplementedError("played_before not implemented for lobby_prompts")
         else:
             conditions.append('runs.start_time <= DATE_ADD(prompts.active_start, INTERVAL %(played_before)s MINUTE)')
             query_args['played_before'] = played_before
@@ -149,7 +151,7 @@ def get_leaderboard_runs(
 
             # This is gross so let me explain this
             # Basically, we want to figure out which (finished) run for a user is his shortest.
-            #   - In terms of colums, this is the MIN(finished, path_length)
+            #   - In terms of column, this is the MIN(finished, path_length)
             #   - Instead of grouping by user (+ name for lobbies), we use a window function to calculate
             #     the order of shortest path for all runs for each user
             #   - Then in the outer query we only select the first.
@@ -189,7 +191,7 @@ def get_leaderboard_runs(
         sort_exp += ' DESC'
 
 
-    # Pagination, default 1 so all articles are chose
+    # Pagination, default 1 so all articles are chosen
     pagination_clause = '1'
     if limit is not None:
         pagination_clause = ("(`rank` BETWEEN %(page_start)s AND %(page_end)s)")
@@ -208,7 +210,7 @@ def get_leaderboard_runs(
     # Some specifics
     assert(len(conditions) > 0)
 
-    # TODO maybe dont' use * here and instead select specific columns?
+    # TODO maybe don't use * here and instead select specific columns?
     # TODO save path length elsewhere?
     # TODO query performance with row_number might not be great
 
@@ -231,9 +233,11 @@ def get_leaderboard_runs(
     ORDER BY {sort_exp}
     """
 
+    if query_only:
+        return { "query": query, "args": query_args }
+
     db = get_db()
     with db.cursor(cursor=pymysql.cursors.DictCursor) as cursor:
-        print(cursor.mogrify(query, query_args))
         cursor.execute(query, query_args)
 
         results = cursor.fetchall()
@@ -253,6 +257,42 @@ def get_leaderboard_runs(
             "runs": results
         }
 
+
+'''
+Leaderboard Stats
+'''
+
+def get_leaderboard_stats(
+    prompt_id: int,
+    lobby_id: Optional[int] = None,
+    **kwargs
+): 
+    lb_query = get_leaderboard_runs(prompt_id, lobby_id, limit=None, offset=0, query_only=True, **kwargs)
+    response = {}
+
+    # Success Rate
+    query = f'''
+    WITH data AS (
+        {lb_query['query']}
+    )
+
+    SELECT
+        COUNT(IF(finished, 1, NULL)) / COUNT(*) * 100 AS finish_pct
+    FROM data
+    '''
+    
+    db = get_db()
+    with db.cursor(cursor=pymysql.cursors.DictCursor) as cursor:
+        print(cursor.mogrify(query, lb_query['args']))
+        cursor.execute(query, lb_query['args'])
+
+        results = cursor.fetchall()
+
+        return results[0]
+
+    # Avg. # of Clicks
+
+    # Avg. Completion Time
 
 '''
 if __name__ == "__main__":

--- a/wikispeedruns/leaderboards.py
+++ b/wikispeedruns/leaderboards.py
@@ -238,6 +238,7 @@ def get_leaderboard_runs(
 
     db = get_db()
     with db.cursor(cursor=pymysql.cursors.DictCursor) as cursor:
+        print(cursor.mogrify(query, query_args))
         cursor.execute(query, query_args)
 
         results = cursor.fetchall()
@@ -265,9 +266,10 @@ Leaderboard Stats
 def get_leaderboard_stats(
     prompt_id: int,
     lobby_id: Optional[int] = None,
+    run_id: Optional[int] = None,
     **kwargs
 ): 
-    lb_query = get_leaderboard_runs(prompt_id, lobby_id, limit=None, offset=0, query_only=True, **kwargs)
+    lb_query = get_leaderboard_runs(prompt_id, lobby_id, run_id, limit=None, offset=0, query_only=True, **kwargs)
     response = {}
 
     # Success Rate
@@ -277,7 +279,9 @@ def get_leaderboard_stats(
     )
 
     SELECT
-        COUNT(IF(finished, 1, NULL)) / COUNT(*) * 100 AS finish_pct
+        COUNT(IF(finished, 1, NULL)) / COUNT(*) * 100 AS finish_pct,
+        AVG(IF(finished, path_length, NULL)) AS avg_path_len,
+        AVG(IF(finished, play_time, NULL)) AS avg_play_time
     FROM data
     '''
     

--- a/wikispeedruns/leaderboards.py
+++ b/wikispeedruns/leaderboards.py
@@ -238,7 +238,6 @@ def get_leaderboard_runs(
 
     db = get_db()
     with db.cursor(cursor=pymysql.cursors.DictCursor) as cursor:
-        print(cursor.mogrify(query, query_args))
         cursor.execute(query, query_args)
 
         results = cursor.fetchall()
@@ -270,7 +269,6 @@ def get_leaderboard_stats(
     **kwargs
 ): 
     lb_query = get_leaderboard_runs(prompt_id, lobby_id, run_id, limit=None, offset=0, query_only=True, **kwargs)
-    response = {}
 
     query = f'''
     WITH data AS (
@@ -286,12 +284,8 @@ def get_leaderboard_stats(
     
     db = get_db()
     with db.cursor(cursor=pymysql.cursors.DictCursor) as cursor:
-        print(cursor.mogrify(query, lb_query['args']))
         cursor.execute(query, lb_query['args'])
-
-        results = cursor.fetchall()
-
-        return results[0]
+        return cursor.fetchall()[0]
 
 '''
 if __name__ == "__main__":


### PR DESCRIPTION
Adds metrics for completion rate, average play time (of completed runs), and average # of clicks (of completed runs) onto leaderboard pages for sprint prompts and lobby prompts. 

Dynamically updates depending on which leadership mode the user selects (uses all runs from whichever mode is selected).

Adds support for mobile viewing as well.

Test:

Basic view
<img width="1728" alt="Screen Shot 2022-08-02 at 6 13 01 PM" src="https://user-images.githubusercontent.com/17424008/182502932-0bcb5a89-66da-43c9-a174-b94d6108273b.png">

Changing leaderboard mode
<img width="1727" alt="Screen Shot 2022-08-02 at 6 13 46 PM" src="https://user-images.githubusercontent.com/17424008/182503001-f24c66a1-3314-47d5-8ecd-e2407b0d723a.png">

Mobile
<img width="1725" alt="Screen Shot 2022-08-02 at 6 14 29 PM" src="https://user-images.githubusercontent.com/17424008/182503089-2d6ddc30-7f35-4bad-84b1-2f7d3ad20fb2.png">

Lobby
<img width="1721" alt="Screen Shot 2022-08-02 at 7 17 44 PM" src="https://user-images.githubusercontent.com/17424008/182509953-2138fb34-391f-474b-a213-95281c18fa75.png">

