### PR TITLE
Sharing past results from leaderboard

### DIFF
--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -1,7 +1,5 @@
 import { serverData } from "./modules/serverData.js"
 import { fetchJson } from "./modules/fetch.js"
-
-
 import { pathArrowFilter } from "./modules/game/filters.js";
 
 const URL_PROMPT_ID = serverData["prompt_id"];
@@ -28,6 +26,24 @@ var LeaderboardRow = {
         }
     },
 
+    methods: {
+        copyResults: function(run) {
+            console.log(run);
+            let results = this.generateResults(run);
+            document.getElementById("custom-tooltip").style.display = "inline";
+            document.getElementById("share-btn").style.display = "none";
+            navigator.clipboard.writeText(results);
+            setTimeout(function() {
+                document.getElementById("custom-tooltip").style.display = "none";
+                document.getElementById("share-btn").style.display = "inline-block";
+            }, 2000);
+        },
+
+        generateResults: function(run) {
+            return `Wiki Speedruns ${run.prompt_id}\n${run.path[0].article}\n${run.path.length - 1} 🖱️\n${(run.play_time)} ⏱️`
+        },
+    },
+
 
     template: (`
         <tr v-bind:class="run.finished ? '' : 'text-danger'">
@@ -47,11 +63,11 @@ var LeaderboardRow = {
 
             <td class="l-col">
                 <template v-if="run.username">
-                    <strong v-if="run.run_id === currentRunId">Your Last Run</strong>
+                    <strong v-if="run.run_id === currentRunId">{{run.username}}</strong>
                     <span v-else>{{run.username}}</span>
                 </template>
                 <template v-else-if="run.name">
-                    <strong v-if="run.run_id === currentRunId">Your Last Run</strong>
+                    <strong v-if="run.run_id === currentRunId">{{run.name}}</strong>
                     <span v-else>{{run.name}}</span>
                 </template>
                 <template v-else>
@@ -65,14 +81,19 @@ var LeaderboardRow = {
             <td class="l-col">{{(run.play_time).toFixed(3)}} s</td>
             <td>{{run.path.length}}</td>
 
-            <td style="min-width:400px">
+            <td class="col-lg">
                 {{run.path | pathArrow}}
                 <a v-if="!lobbyId" v-bind:href="'/replay?run_id=' + run.run_id" target="_blank" title="Replay" >
                     <i class="bi bi-play"></i>
                 </a>
             </td>
 
-
+            <td class="col">
+                <div v-if="run.run_id === currentRunId" class="button-tooltip-container col-auto py-2">
+                    <button @click="copyResults(run)" id="share-btn" class="share-btn btn-1 btn-1c"><i class="bi bi-share"></i> Share</button>
+                    <span id="custom-tooltip">Copied results to clipboard!</span>
+                </div>
+            </td>
         </tr>
     `)
 }

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -7,6 +7,7 @@ const URL_LOBBY_ID = serverData["lobby_id"] || null;
 
 // Hack, if USER_ID = -1 the server shouldn't return anything.
 const USER_ID = serverData["user_id"] === undefined ? -1 : serverData["user_id"];
+const USERNAME = USER_ID < 0 ? '' : serverData["username"];
 
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -101,7 +102,11 @@ var LeaderboardRow = {
             </td>
 
             <td class="col">
-                <div v-if="run.run_id === currentRunId" class="button-tooltip-container col-auto py-2">
+                <div 
+                    v-if="run.run_id === currentRunId && 
+                    (run.username === this.$parent.username || (this.$parent.preset === 'personal' && !this.$parent.loggedIn))" 
+                    class="button-tooltip-container col-auto py-2"
+                >
                     <button @click="copyResults(run)" id="share-btn" class="share-btn btn-1 btn-1c"><i class="bi bi-share"></i> Share</button>
                     <span id="custom-tooltip">Copied results to clipboard!</span>
                 </div>
@@ -294,6 +299,7 @@ var app = new Vue({
     el: '#app',
     data: {
         loggedIn: USER_ID !== -1,
+        username: USERNAME,
         prompt: {},
         available: false,
 

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -60,7 +60,7 @@ var LeaderboardRow = {
     },
 
     template: (`
-        <tr :class="run.finished ? '' : 'text-danger'" @click="goToRun(run.run_id)">
+        <tr :class="[run.finished ? '' : 'text-danger', 'clickable']" @click="goToRun(run.run_id)">
             <td >
                 {{run.rank}}
                 <button

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -103,7 +103,8 @@ var LeaderboardRow = {
 
             <td class="col">
                 <div 
-                    v-if="run.run_id === currentRunId && 
+                    v-if="run.finished && 
+                    run.run_id === currentRunId && 
                     (run.username === this.$parent.username || (this.$parent.preset === 'personal' && !this.$parent.loggedIn))" 
                     class="button-tooltip-container col-auto py-2"
                 >

--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -10,7 +10,7 @@ const USER_ID = serverData["user_id"] === undefined ? -1 : serverData["user_id"]
 
 const DEFAULT_PAGE_SIZE = 20;
 
-Vue.filter('pathArrow', pathArrowFilter)
+Vue.filter('pathArrow', pathArrowFilter);
 
 var LeaderboardRow = {
     props: [
@@ -40,14 +40,26 @@ var LeaderboardRow = {
         },
 
         generateResults: function(run) {
-            return `Wiki Speedruns ${run.prompt_id}\n${run.path[0].article}\n${run.path.length - 1} 🖱️\n${(run.play_time)} ⏱️`
+            return `Wiki Speedruns ${run.prompt_id}\n${this.$parent.prompt.start}\n${run.path.length - 1} 🖱️\n${(run.play_time)} ⏱️`
         },
+
+        goToRun: function(newRunId) {
+            if (newRunId === this.$props.currentRunId) return;
+            
+            let url = new URL(window.location.href);
+            url.searchParams.set('run_id', newRunId);
+            window.location.replace(url);
+        }
     },
 
+    mounted: async function() {
+        if (this.$props.run.run_id === this.$props.currentRunId) {
+            this.$el.scrollIntoView({behavior: "smooth", block: "end", inline: "nearest"});
+        }
+    },
 
     template: (`
-        <tr v-bind:class="run.finished ? '' : 'text-danger'">
-
+        <tr :class="run.finished ? '' : 'text-danger'" @click="goToRun(run.run_id)">
             <td >
                 {{run.rank}}
                 <button
@@ -330,8 +342,7 @@ var app = new Vue({
         },
 
 
-        goToPage: function(newPage)
-        {
+        goToPage: function(newPage) {
             let url = new URL(window.location.href);
             url.searchParams.set('offset', newPage * this.limit);
             url.searchParams.set('limit', this.limit);
@@ -420,9 +431,6 @@ var app = new Vue({
             }
         }
 
-
-
-
         this.genGraph();
-    }
+    },
 })

--- a/static/stylesheets/leaderboard.css
+++ b/static/stylesheets/leaderboard.css
@@ -1,0 +1,88 @@
+/* Button CSS courtesy of https://tympanus.net/Development/CreativeButtons/ */
+/* General button style (reset) */
+.share-btn {
+	border: none;
+    border-radius: 5px;
+	font-family: inherit;
+	font-size:medium;
+	color: inherit;
+	background: #0e83cd;
+	cursor: pointer;
+	padding: 5px 10px;
+	display: inline-block;
+	/*margin: 20px 0px;*/
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	font-weight: 700;
+	outline: none;
+	position: relative;
+	-webkit-transition: all 0.3s;
+	-moz-transition: all 0.3s;
+	transition: all 0.3s;
+}
+
+.share-btn:after {
+	content: '';
+	position: absolute;
+	z-index: -1;
+	-webkit-transition: all 0.3s;
+	-moz-transition: all 0.3s;
+	transition: all 0.3s;
+}
+
+
+.share-btn:before {
+	font-style: normal;
+	font-weight: normal;
+	font-variant: normal;
+	text-transform: none;
+	line-height: 1;
+	position: relative;
+	-webkit-font-smoothing: antialiased;
+}
+
+/* Button 1 */
+.btn-1 {
+	color: #ffffff;
+}
+
+.btn-1c::before {
+    background: #0e83cd;
+}
+
+/* Button 1c */
+.btn-1c:after {
+	width: 0%;
+	height: 100%;
+	top: 0;
+	left: 0;
+}
+
+.btn-1c:hover,
+.btn-1c:active {
+    border:3px solid #0e83cd;
+	color: #0e83cd;
+    background: #ffffff;
+}
+
+.btn-1c:hover:after,
+.btn-1c:active:after {
+	width: 100%;
+}
+
+/* Tooltip */
+.button-tooltip-container {
+    display: flex;
+    align-items: center;
+    min-height: 10px;
+
+}
+
+#custom-tooltip, #custom-tooltip-path {
+    display: none;
+    margin-left: 5px;
+    padding: 5px 10px;
+    background-color: #000000df;
+    border-radius: 5px;
+    color: #fff;
+}

--- a/static/stylesheets/leaderboard.css
+++ b/static/stylesheets/leaderboard.css
@@ -86,3 +86,6 @@
     border-radius: 5px;
     color: #fff;
 }
+.clickable {
+    cursor: pointer;
+}

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -109,7 +109,7 @@
                                 v-on:go-to-page="goToPage"
                             ></tr>
 
-                            <tr v-if="currentRunPosition === -1"><td colspan="5">...</td></tr>
+                            <tr v-if="currentRunPosition === -1"><td colspan="6">...</td></tr>
 
                             <tr is="leaderboard-row"
                                 v-for="run in runs"
@@ -118,7 +118,7 @@
                                 v-bind:current-run-id="runId"
                             ></tr>
 
-                            <tr v-if="currentRunPosition === 1"><td colspan="5">...</td></tr>
+                            <tr v-if="currentRunPosition === 1"><td colspan="6">...</td></tr>
                             <tr is="leaderboard-row"
                                 v-if="currentRunPosition === 1"
                                 v-bind:run="currentRun"

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -6,9 +6,10 @@
 <script src="{{url_for('static', filename='js/springy-master/springy.js') }}"></script>
 <script src="{{url_for('static', filename='js/springy-master/springyui.js') }}"></script>
 
+<link rel="stylesheet" type= "text/css" href="{{url_for('static', filename='stylesheets/leaderboard.css')}}">
+
 <!-- Some nice x minutes ago tags -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js"></script>
-
 <script defer type="module" src="{{url_for('static', filename='js/leaderboard.js') }}"></script>
 {% endblock %}
 


### PR DESCRIPTION
You can now click on run entries on leaderboards to view that particular run.

A Share button appears for the selected run if it is:
* finished
* yours

The window scrolls to the newly selected run when page updates (no SPA so this is the workaround zzz 🙏 #414) 

Closes #309

https://user-images.githubusercontent.com/17424008/183758006-910417b8-88b7-40fe-9cf2-c83c580e4e8d.mp4


Note: This will merge conflict with my other PR #417 (they both create `leaderboard.css`) but when that gets merged in I'll update this one