### PR TITLE
clicking username in leaderboard would actually lead to profile page

### DIFF
--- a/static/js/leaderboard.js
+++ b/static/js/leaderboard.js
@@ -83,8 +83,7 @@ var LeaderboardRow = {
 
             <td class="l-col">
                 <template v-if="run.username">
-                    <strong v-if="run.run_id === currentRunId">{{run.username}}</strong>
-                    <user v-else :username="run.username" />
+                    <user :username="run.username" :bolded="run.run_id === currentRunId"/>
                 </template>
                 <template v-else-if="run.name">
                     <strong v-if="run.run_id === currentRunId">{{run.name}}</strong>

--- a/static/js/modules/userDisplay.js
+++ b/static/js/modules/userDisplay.js
@@ -15,18 +15,12 @@ var UserDisplay = {
         }
 	},
 
-    methods: {
-        goToProfile() {
-            window.location.replace(this.link);
-        }
-    },
-
     mounted: function() {
         this.link = `/profile/${this.username}`;
     },
 
     template: (`
-        <a :style="{ 'cursor': 'pointer', 'font-weight': bolded ? 'bold' : 'initial' }" @click.stop="goToProfile">{{username}}</a>
+        <a :href="link" :style="{ 'color': 'inherit', 'cursor': 'pointer', 'font-weight': bolded ? 'bold' : 'initial' }" @click.stop="">{{username}}</a>
     `)
 };
 

--- a/static/js/modules/userDisplay.js
+++ b/static/js/modules/userDisplay.js
@@ -2,7 +2,11 @@
 var UserDisplay = {
 
     props: {
-        username: String
+        username: String,
+        bolded: {
+            type: Boolean,
+            default: false
+        }
     },
 
     data: function () {
@@ -22,7 +26,7 @@ var UserDisplay = {
     },
 
     template: (`
-        <a style="cursor:pointer" @click="goToProfile">{{username}}</a>
+        <a :style="{ 'cursor': 'pointer', 'font-weight': bolded ? 'bold' : 'initial' }" @click.stop="goToProfile">{{username}}</a>
     `)
 };
 


### PR DESCRIPTION
A pretty quick change. Clicking on the username in the leaderboard would override the action of clicking on the row and would redirect to the user profile page. I removed the replace window function with a redirect so that the user can come back to their initial page. Otherwise, clicking on the row will still put it in focus and the rest of the functionality are intact.