### PR TITLE
Add start_time to run creation from server-side

### DIFF
--- a/wikispeedruns/runs.py
+++ b/wikispeedruns/runs.py
@@ -49,19 +49,20 @@ def _create_run(prompt_id, lobby_id=None, user_id=None, name=None):
     '''
 
     query_args = {
-        "prompt_id" : prompt_id
+        "prompt_id" : prompt_id,
+        "start_time": datetime.now(),
     }
 
 
     if lobby_id is None:
-        query = "INSERT INTO `sprint_runs` (`prompt_id`,`user_id`) \
-                 VALUES (%(prompt_id)s, %(user_id)s);"
+        query = "INSERT INTO `sprint_runs` (`prompt_id`,`user_id`, `start_time`) \
+                 VALUES (%(prompt_id)s, %(user_id)s, %(start_time)s);"
 
         query_args["user_id"] = user_id
 
     else:
-        query = "INSERT INTO `lobby_runs` (`lobby_id`, `prompt_id`,  `user_id`, `name`) \
-                 VALUES (%(lobby_id)s, %(prompt_id)s, %(user_id)s, %(name)s)"
+        query = "INSERT INTO `lobby_runs` (`lobby_id`, `prompt_id`,  `user_id`, `start_time`, `name`) \
+                 VALUES (%(lobby_id)s, %(prompt_id)s, %(user_id)s, %(start_time)s, %(name)s)"
 
         if (user_id is None and name is None):
             raise ValueError("'user_id' or 'name' should be defined for lobby prompt")


### PR DESCRIPTION
Although it's slightly inaccurate compared to client-side timing, this should fix #420 (nulls in the db) and perhaps some insights on #434 (this is probably more of a client-side issue).

Test:
```
INSERT INTO `sprint_runs` (`prompt_id`,`user_id`, `start_time`)                  VALUES (18, 44, '2022-11-27 20:02:43.314496');
127.0.0.1 - - [27/Nov/2022 20:02:43] "POST /api/sprints/18/runs HTTP/1.1" 200 -

        UPDATE `sprint_runs`
        SET `start_time`='2022-11-27 20:02:43.274000', `end_time`='2022-11-27 20:02:43.669000', `play_time`=0.0e0, `finished`=0, `path`='{\"version\": \"2.3\", \"path\": [{\"article\": \"37 (number)\", \"timeReached\": 0.395, \"loadTime\": 0.344}]}'
        WHERE `run_id`=658
        
127.0.0.1 - - [27/Nov/2022 20:02:43] "PATCH /api/sprints/18/runs/658 HTTP/1.1" 200 -

        UPDATE `sprint_runs`
        SET `start_time`='2022-11-27 20:02:43.274000', `end_time`='2022-11-27 20:02:45.063000', `play_time`=1.394e0, `finished`=0, `path`='{\"version\": \"2.3\", \"path\": [{\"article\": \"37 (number)\", \"timeReached\": 0.395, \"loadTime\": 0.344}]}'
        WHERE `run_id`=658
        
127.0.0.1 - - [27/Nov/2022 20:02:45] "PATCH /api/sprints/18/runs/658 HTTP/1.1" 200 -
```

So server-side is about 0.04s inaccurate on my local instance, but at least will be an approximate placeholder until a PATCH from the client is received.