### PR TITLE
Loading timer on pulling new stats, fix date shown

### DIFF
--- a/apis/stats_api.py
+++ b/apis/stats_api.py
@@ -25,7 +25,15 @@ def calculate_stats():
 @stats_api.get("/all")
 @check_admin
 def get_total_stats():
-    most_recent_stats_query = 'SELECT * FROM `computed_stats` ORDER BY `timestamp` DESC LIMIT 1'
+    most_recent_stats_query = """
+    SELECT 
+        stats_json, 
+        DATE_FORMAT(timestamp, '%Y-%m-%dT%TZ') AS timestamp
+    FROM `computed_stats` 
+    ORDER BY `timestamp` 
+    DESC 
+    LIMIT 1
+    """
 
     db = get_db()
     with db.cursor(cursor=DictCursor) as cursor:

--- a/db.py
+++ b/db.py
@@ -35,16 +35,12 @@ def close_db(exception):
         db.close()
 
 @contextmanager
-def use_instance_db(conn={}):
+def use_instance_db(conn):
     """
     Usage: 
-    with use_instance_db() as db:
+    with use_instance_db(conn) as db:
         do stuff with db
     """
-    if not conn:
-        # Needs to have app context if no conn info passed in
-        conn = get_conn_info() 
-
     try:
         global _instance_db
         _instance_db = pymysql.connect(**conn)

--- a/static/js/pages/admin/stats.js
+++ b/static/js/pages/admin/stats.js
@@ -437,6 +437,7 @@ var app = new Vue({
         },
         active_tab: 'users',
         loading: false,
+        load_time_sec: 0,
         last_updated: '',
         last_request_time: ''
     },
@@ -469,6 +470,8 @@ var app = new Vue({
                     alert("New stat calculation underway.");
                     this.last_request_time = new Date();
                     this.loading = true;
+                    this.load_time_sec = 0;
+                    this.countLoadTimer();
                 } else if (response.status === 503) {
                     alert("Server currently processing stats! Check back in a bit.");
                 }
@@ -479,6 +482,14 @@ var app = new Vue({
                 alert(e);
             }
         },
+        countLoadTimer() {
+            if (this.loading) {
+                setTimeout(() => {
+                    this.load_time_sec += 1
+                    this.countLoadTimer()
+                }, 1000)
+            }
+        }
     },
 
     created: async function () {

--- a/templates/admin/stats.html
+++ b/templates/admin/stats.html
@@ -12,7 +12,8 @@
 
 <div id="app">
     <div class="updated-time">Last Updated: [[last_updated.toLocaleString()]]     
-        <a href="#" @click="refresh_stats"><i class="bi bi-arrow-clockwise"></i></a>
+        <a v-if="!loading" href="#" @click="refresh_stats"><i class="bi bi-arrow-clockwise"></i></a>
+        <div v-else>Loading... [[load_time_sec]]</div>
     </div>
     <div class="box-wrapper" @click.prevent>
         <a class="box" @click="set_active('users')" :class="{active: is_active('users')}">

--- a/wikispeedruns/stats.py
+++ b/wikispeedruns/stats.py
@@ -52,7 +52,7 @@ def calculate() -> dict:
 
     db = get_db()
     with db.cursor(cursor=DictCursor) as cursor:
-        cursor.execute(query, (stat_json_str, datetime.now())) 
+        cursor.execute(query, (stat_json_str, datetime.now().isoformat())) 
 
     db.commit()
 

--- a/wikispeedruns/stats.py
+++ b/wikispeedruns/stats.py
@@ -2,7 +2,7 @@ import json
 
 from multiprocessing import Lock
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 from db import get_db, get_db_version
 from pymysql.cursors import DictCursor
 from util.flaskjson import CustomJSONEncoder
@@ -52,7 +52,7 @@ def calculate() -> dict:
 
     db = get_db()
     with db.cursor(cursor=DictCursor) as cursor:
-        cursor.execute(query, (stat_json_str, datetime.now().isoformat())) 
+        cursor.execute(query, (stat_json_str, datetime.now(timezone.utc))) 
 
     db.commit()
 


### PR DESCRIPTION
Adds an incrementing counter while we are polling for stats.

Also always use utc time so it works regardless of device time. 


<img width="386" alt="Screen Shot 2022-11-30 at 1 08 05 AM" src="https://user-images.githubusercontent.com/17424008/204759362-479c1141-7f4c-43f6-878d-76b324f08fea.png">
