### PR TITLE
Active player counts on stats page

### DIFF
--- a/static/js/pages/admin/stats.js
+++ b/static/js/pages/admin/stats.js
@@ -25,6 +25,13 @@ function update_totals(totals) {
     app.totals.finished_lobby_runs = totals['lobby_runs_finished'];
     app.totals.created_lobbies = totals['lobbies_created'];
 
+    app.totals.daily_active_users = totals['daily_active_users'];
+    app.totals.weekly_active_users = totals['weekly_active_users'];
+    app.totals.monthly_active_users = totals['weekly_active_users'];
+    app.totals.daily_active_users_finished = totals['daily_active_users_finished'];
+    app.totals.weekly_active_users_finished = totals['weekly_active_users_finished'];
+    app.totals.monthly_active_users_finished = totals['monthly_active_users_finished'];
+
     let user_runs = totals['user_runs'];
     let user_finished_runs = totals['user_finished_runs'];
     let user_marathons = totals['user_marathons'];
@@ -414,6 +421,12 @@ var app = new Vue({
             pct_user_finished_runs: 0.0,
             pct_user_marathons: 0.0,
             pct_user_finished_marathons: 0.0,
+            daily_active_users: 0,
+            weekly_active_users: 0,
+            monthly_active_users: 0,
+            daily_active_users_finished: 0,
+            weekly_active_users_finished: 0,
+            monthly_active_users_finished: 0,
         },
         weekly: {
             user_change: 0.0,

--- a/static/stylesheets/stats.css
+++ b/static/stylesheets/stats.css
@@ -163,7 +163,7 @@ canvas {
 }
 
 .grow { 
-    transition: all .1s ease-in-out; 
+    transition: all .2s ease-in-out; 
 }
     
 .grow:hover { 

--- a/static/stylesheets/stats.css
+++ b/static/stylesheets/stats.css
@@ -90,6 +90,36 @@ canvas {
 	padding: 1em;
 }
 
+.daily {
+    background: #1976D2;
+}
+
+.weekly {
+    background: #1565C0;
+}
+
+.monthly {
+    background: #0D47A1;
+}
+
+.active-user-group {
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    gap: .6em;
+}
+
+.active-user-box {
+    border-radius: 5px;
+
+    margin-bottom: 2em;
+    margin-top: .5em;
+
+    padding-left: .5em;
+    padding-right: .5em;
+    color: white;
+}
+
 .stats {
 	color: #fff;
 	position: relative;
@@ -130,4 +160,12 @@ canvas {
 
 .updated-time {
     text-align: center;
+}
+
+.grow { 
+    transition: all .1s ease-in-out; 
+}
+    
+.grow:hover { 
+    transform: scale(1.05); 
 }

--- a/static/stylesheets/stats.css
+++ b/static/stylesheets/stats.css
@@ -91,15 +91,15 @@ canvas {
 }
 
 .daily {
-    background: #1976D2;
+    background: #1b80e5;
 }
 
 .weekly {
-    background: #1565C0;
+    background: #135bac;
 }
 
 .monthly {
-    background: #0D47A1;
+    background: #0a3370;
 }
 
 .active-user-group {
@@ -112,8 +112,7 @@ canvas {
 .active-user-box {
     border-radius: 5px;
 
-    margin-bottom: 2em;
-    margin-top: .5em;
+    margin-top: 1em;
 
     padding-left: .5em;
     padding-right: .5em;

--- a/templates/admin/stats.html
+++ b/templates/admin/stats.html
@@ -56,6 +56,15 @@
     </div>
 
     <div class="tab-content">
+        <div class="active-user-group">
+            <div class="active-user-box daily grow">DAU [[totals.daily_active_users]]</div>
+            <div class="active-user-box weekly grow">WAU [[totals.weekly_active_users]]</div>
+            <div class="active-user-box monthly grow">MAU [[totals.monthly_active_users]]</div>
+            <div></div>
+            <div class="active-user-box daily grow">FDAU [[totals.daily_active_users_finished]]</div>
+            <div class="active-user-box weekly grow">FWAU [[totals.daily_active_users_finished]]</div>
+            <div class="active-user-box monthly grow">FMAU [[totals.daily_active_users_finished]]</div>
+        </div>
         <div class="tab-pane fade" :class="{'active show': is_active('users')}">
             <div class="col-xs-6">
                 <canvas id="daily-users" width="{{chart_width}}" height="{{chart_height}}"></canvas>

--- a/templates/admin/stats.html
+++ b/templates/admin/stats.html
@@ -14,6 +14,39 @@
     <div class="updated-time">Last Updated: [[last_updated.toLocaleString()]]     
         <a href="#" @click="refresh_stats"><i class="bi bi-arrow-clockwise"></i></a>
     </div>
+        <div class="active-user-group">
+            <div class="active-user-box daily grow"
+                title="Daily Active Users - # of users who started either a sprint or lobby run">
+                DAU [[totals.daily_active_users]] 
+            </div>
+
+            <div class="active-user-box weekly grow"
+                title="Weekly Active Users - # of users who started either a sprint or lobby run">
+                WAU [[totals.weekly_active_users]]
+            </div>                
+
+            <div class="active-user-box monthly grow"
+                title="Monthly Active Users - # of users who started either a sprint or lobby run">
+                MAU [[totals.monthly_active_users]]
+            </div>   
+
+            <div></div>
+
+            <div class="active-user-box daily grow"
+                title="Finished Runs DAU - # of users who finished either a sprint or lobby run">
+                FDAU [[totals.daily_active_users_finished]] 
+            </div>
+
+            <div class="active-user-box weekly grow"
+                title="Finished Runs WAU - # of users who finished either a sprint or lobby run">
+                FWAU [[totals.weekly_active_users_finished]] 
+            </div>
+
+            <div class="active-user-box monthly grow"
+                title="Finished Runs MAU - # of users who finished either a sprint or lobby run">
+                FMAU [[totals.monthly_active_users_finished]] 
+            </div>
+        </div>
     <div class="box-wrapper" @click.prevent>
         <a class="box" @click="set_active('users')" :class="{active: is_active('users')}">
             <div class="stats">
@@ -56,40 +89,6 @@
     </div>
 
     <div class="tab-content">
-        <div class="active-user-group">
-            <div class="active-user-box daily grow"
-                title="Daily Active Users - # of users who started either a sprint or lobby run">
-                DAU [[totals.daily_active_users]] 
-            </div>
-
-            <div class="active-user-box weekly grow"
-                title="Weekly Active Users - # of users who started either a sprint or lobby run">
-                WAU [[totals.weekly_active_users]]
-            </div>                
-
-            <div class="active-user-box monthly grow"
-                title="Monthly Active Users - # of users who started either a sprint or lobby run">
-                MAU [[totals.monthly_active_users]]
-            </div>   
-
-            <div></div>
-
-            <div class="active-user-box daily grow"
-                title="Finished Runs DAU - # of users who finished either a sprint or lobby run">
-                FDAU [[totals.daily_active_users_finished]] 
-            </div>
-
-            <div class="active-user-box weekly grow"
-                title="Finished Runs WAU - # of users who finished either a sprint or lobby run">
-                FWAU [[totals.weekly_active_users_finished]] 
-            </div>
-
-            <div class="active-user-box monthly grow"
-                title="Finished Runs MAU - # of users who finished either a sprint or lobby run">
-                FMAU [[totals.monthly_active_users_finished]] 
-            </div>
-
-        </div>
         <div class="tab-pane fade" :class="{'active show': is_active('users')}">
             <div class="col-xs-6">
                 <canvas id="daily-users" width="{{chart_width}}" height="{{chart_height}}"></canvas>

--- a/templates/admin/stats.html
+++ b/templates/admin/stats.html
@@ -57,13 +57,38 @@
 
     <div class="tab-content">
         <div class="active-user-group">
-            <div class="active-user-box daily grow">DAU [[totals.daily_active_users]]</div>
-            <div class="active-user-box weekly grow">WAU [[totals.weekly_active_users]]</div>
-            <div class="active-user-box monthly grow">MAU [[totals.monthly_active_users]]</div>
+            <div class="active-user-box daily grow"
+                title="Daily Active Users - # of users who started either a sprint or lobby run">
+                DAU [[totals.daily_active_users]] 
+            </div>
+
+            <div class="active-user-box weekly grow"
+                title="Weekly Active Users - # of users who started either a sprint or lobby run">
+                WAU [[totals.weekly_active_users]]
+            </div>                
+
+            <div class="active-user-box monthly grow"
+                title="Monthly Active Users - # of users who started either a sprint or lobby run">
+                MAU [[totals.monthly_active_users]]
+            </div>   
+
             <div></div>
-            <div class="active-user-box daily grow">FDAU [[totals.daily_active_users_finished]]</div>
-            <div class="active-user-box weekly grow">FWAU [[totals.daily_active_users_finished]]</div>
-            <div class="active-user-box monthly grow">FMAU [[totals.daily_active_users_finished]]</div>
+
+            <div class="active-user-box daily grow"
+                title="Finished Runs DAU - # of users who finished either a sprint or lobby run">
+                FDAU [[totals.daily_active_users_finished]] 
+            </div>
+
+            <div class="active-user-box weekly grow"
+                title="Finished Runs WAU - # of users who finished either a sprint or lobby run">
+                FWAU [[totals.weekly_active_users_finished]] 
+            </div>
+
+            <div class="active-user-box monthly grow"
+                title="Finished Runs MAU - # of users who finished either a sprint or lobby run">
+                FMAU [[totals.monthly_active_users_finished]] 
+            </div>
+
         </div>
         <div class="tab-pane fade" :class="{'active show': is_active('users')}">
             <div class="col-xs-6">

--- a/wikispeedruns/stats.py
+++ b/wikispeedruns/stats.py
@@ -16,9 +16,9 @@ class AggregateStat(Enum):
     WAU = 'weekly_active_users',
     MAU = 'monthly_active_users',
 
-    FDAU = 'daily_active_users_finished_run',
-    FWAU = 'weekly_active_users_finished_run',
-    FMAU = 'monthly_active_users_finished_run',
+    FDAU = 'daily_active_users_finished',
+    FWAU = 'weekly_active_users_finished',
+    FMAU = 'monthly_active_users_finished',
 
     RUNS = 'total_runs',
     FINISHED_RUNS = 'total_finished_runs',
@@ -64,18 +64,42 @@ def calculate() -> dict:
 
     db.commit()
 
+def _active_user_query(freq, finished=False):
+    mapping = {'daily':'DAY', 'weekly':'WEEK', 'monthly':'MONTH'}
+    if freq not in mapping:
+        raise KeyError(f'{freq} not in {{daily, weekly, monthly}}')
+
+    finished_cond = ''
+    finished_col_name = ''
+    if finished:
+        finished_cond = 'finished AND'
+        finished_col_name = '_finished'
+
+    return f'''
+    SELECT COUNT(DISTINCT user_id) AS {freq}_active_users{finished_col_name} 
+    FROM (
+        SELECT DISTINCT user_id
+        FROM sprint_runs
+        WHERE {finished_cond} start_time > NOW() - INTERVAL 1 {mapping[freq]}
+        UNION
+        SELECT DISTINCT user_id
+        FROM lobby_runs
+        WHERE {finished_cond} start_time > NOW() - INTERVAL 1 {mapping[freq]}
+    ) users
+    '''
+    
 def _calculate_total_stats():
     queries = {}
     queries[AggStat.USERS] = "SELECT COUNT(*) AS users_total FROM users"
     queries[AggStat.GOOGLE_USERS] = 'SELECT COUNT(*) AS goog_total FROM users WHERE hash=""'
     
-    queries[AggStat.DAU] = "SELECT COUNT(DISTINCT user_id) AS daily_active_users FROM sprint_runs WHERE user_id IS NOT NULL AND start_time > NOW() - INTERVAL 1 DAY"
-    queries[AggStat.WAU] = "SELECT COUNT(DISTINCT user_id) AS weekly_active_users FROM sprint_runs WHERE user_id IS NOT NULL AND start_time > NOW() - INTERVAL 1 WEEK"
-    queries[AggStat.MAU] = "SELECT COUNT(DISTINCT user_id) AS monthly_active_users FROM sprint_runs WHERE user_id IS NOT NULL AND start_time > NOW() - INTERVAL 1 MONTH"
+    queries[AggStat.DAU] = _active_user_query('daily')
+    queries[AggStat.WAU] = _active_user_query('weekly')
+    queries[AggStat.MAU] = _active_user_query('monthly')
 
-    queries[AggStat.FDAU] = "SELECT COUNT(DISTINCT user_id) AS daily_active_users_finished_run FROM sprint_runs WHERE user_id IS NOT NULL AND finished AND start_time > NOW() - INTERVAL 1 DAY"
-    queries[AggStat.FWAU] = "SELECT COUNT(DISTINCT user_id) AS weekly_active_users_finished_run FROM sprint_runs WHERE user_id IS NOT NULL AND finished AND start_time > NOW() - INTERVAL 1 WEEK"
-    queries[AggStat.FMAU] = "SELECT COUNT(DISTINCT user_id) AS monthly_active_users_finished_run FROM sprint_runs WHERE user_id IS NOT NULL AND finished AND start_time > NOW() - INTERVAL 1 MONTH"
+    queries[AggStat.FDAU] = _active_user_query('daily', finished=True)
+    queries[AggStat.FWAU] = _active_user_query('weekly', finished=True)
+    queries[AggStat.FMAU] = _active_user_query('monthly', finished=True)
 
     queries[AggStat.RUNS] = "SELECT COUNT(*) AS sprints_total FROM sprint_runs"
     queries[AggStat.FINISHED_RUNS] = "SELECT COUNT(*) AS sprints_finished FROM sprint_runs WHERE finished"

--- a/wikispeedruns/stats.py
+++ b/wikispeedruns/stats.py
@@ -12,6 +12,14 @@ class AggregateStat(Enum):
     USERS = 'total_users',
     GOOGLE_USERS = 'total_google_users',
 
+    DAU = 'daily_active_users',
+    WAU = 'weekly_active_users',
+    MAU = 'monthly_active_users',
+
+    FDAU = 'daily_active_users_finished_run',
+    FWAU = 'weekly_active_users_finished_run',
+    FMAU = 'monthly_active_users_finished_run',
+
     RUNS = 'total_runs',
     FINISHED_RUNS = 'total_finished_runs',
     USER_RUNS = 'total_user_runs',
@@ -60,6 +68,14 @@ def _calculate_total_stats():
     queries = {}
     queries[AggStat.USERS] = "SELECT COUNT(*) AS users_total FROM users"
     queries[AggStat.GOOGLE_USERS] = 'SELECT COUNT(*) AS goog_total FROM users WHERE hash=""'
+    
+    queries[AggStat.DAU] = "SELECT COUNT(DISTINCT user_id) AS daily_active_users FROM sprint_runs WHERE user_id IS NOT NULL AND start_time > NOW() - INTERVAL 1 DAY"
+    queries[AggStat.WAU] = "SELECT COUNT(DISTINCT user_id) AS weekly_active_users FROM sprint_runs WHERE user_id IS NOT NULL AND start_time > NOW() - INTERVAL 1 WEEK"
+    queries[AggStat.MAU] = "SELECT COUNT(DISTINCT user_id) AS monthly_active_users FROM sprint_runs WHERE user_id IS NOT NULL AND start_time > NOW() - INTERVAL 1 MONTH"
+
+    queries[AggStat.FDAU] = "SELECT COUNT(DISTINCT user_id) AS daily_active_users_finished_run FROM sprint_runs WHERE user_id IS NOT NULL AND finished AND start_time > NOW() - INTERVAL 1 DAY"
+    queries[AggStat.FWAU] = "SELECT COUNT(DISTINCT user_id) AS weekly_active_users_finished_run FROM sprint_runs WHERE user_id IS NOT NULL AND finished AND start_time > NOW() - INTERVAL 1 WEEK"
+    queries[AggStat.FMAU] = "SELECT COUNT(DISTINCT user_id) AS monthly_active_users_finished_run FROM sprint_runs WHERE user_id IS NOT NULL AND finished AND start_time > NOW() - INTERVAL 1 MONTH"
 
     queries[AggStat.RUNS] = "SELECT COUNT(*) AS sprints_total FROM sprint_runs"
     queries[AggStat.FINISHED_RUNS] = "SELECT COUNT(*) AS sprints_finished FROM sprint_runs WHERE finished"


### PR DESCRIPTION
Adds current daily/weekly/monthly active users to stats page. Historical data for this should be done with #472, but at least we can get an easy snapshot for now.

Test Video:
https://user-images.githubusercontent.com/17424008/206153105-cd19f273-283e-4057-ac41-b929c18ae3ba.mp4


Image:
<img width="666" alt="Screen Shot 2022-12-07 at 2 00 45 AM" src="https://user-images.githubusercontent.com/17424008/206148327-222c749f-1aae-41ba-b16b-4ded3cede7a8.png">

Example tooltip
<img width="605" alt="Screen Shot 2022-12-07 at 2 01 03 AM" src="https://user-images.githubusercontent.com/17424008/206148388-fc96ef49-7a37-4d35-bd34-5612d194fd83.png">

