### PR TITLE
Use revision API in POTD to curb wiki vandalism

### DIFF
--- a/static/js/modules/game/articleRenderer.js
+++ b/static/js/modules/game/articleRenderer.js
@@ -4,14 +4,22 @@ export class ArticleRenderer {
 
     /* frame: DOM element (i.e. through getElementById) to render article in
      * pageCallback: Called upon loading an article, should expect new page and load time
+     *
+     * mouseEnter, mouseLeave: function handlers for hovering over links (i.e. to display a preview)
+     *
+     * loadCallback: callback when page is started to load, lets callers add time
+     *
+     * revisionDate: date for article revisions are tied to.
      */
-    constructor(frame, pageCallback, mouseEnter, mouseLeave, loadCallback, language) {
+    constructor(frame, pageCallback, mouseEnter, mouseLeave, loadCallback, language, revisionDate) {
         this.frame = frame;
         this.pageCallback = pageCallback;
         this.loadCallback = loadCallback;
         this.mouseEnter = mouseEnter;
         this.mouseLeave = mouseLeave;
         this.language = language;
+
+        this.revisionDate = revisionDate;
     }
 
     async loadPage(page) {
@@ -22,7 +30,7 @@ export class ArticleRenderer {
 
             const isMobile = window.screen.width < 768;
             const startTime = Date.now();
-            const body = await getArticle(page, isMobile, this.language);
+            const body = await getArticle(page, isMobile, this.language, this.revisionDate);
 
             this.frame.innerHTML = body["text"]["*"];
 

--- a/static/js/pages/play.js
+++ b/static/js/pages/play.js
@@ -77,13 +77,8 @@ let app = new Vue({
         }
         */
 
-        promptId: null,        //Unique prompt id to load, this should be identical to 'const PROMPT_ID', but is mostly used for display
-        promptRated: false,
-        promptPlayed: false,
-        promptActive: false,
-
-        promptStart: null,     // or get the actual prompt for quick run
-        promptEnd: null,
+        promptId: null,        // Unique prompt id to load, this should be identical to 'const PROMPT_ID', but is mostly used for display
+        revisionDate: null,
 
         lobbyId: null,
         runId: -1,          //unique ID for the current run. This gets populated upon start of run
@@ -134,6 +129,9 @@ let app = new Vue({
         this.promptActive = !!prompt["active"];
         this.promptRated = !!prompt["rated"];
 
+        // Use the release date of teh prompt (if it exists) to determine the article revision
+        this.revisionDate = prompt?.["active_start"];
+
         this.currentArticle = this.startArticle;
 
         this.runId = await startRun(PROMPT_ID, LOBBY_ID, PROMPT_START, PROMPT_END, LANGUAGE);
@@ -145,7 +143,14 @@ let app = new Vue({
 
         this.offset = this.startTime;
 
-        this.renderer = new ArticleRenderer(document.getElementById("wikipedia-frame"), this.pageCallback, !this.isScroll && this.showPreview, !this.isScroll && this.hidePreview, this.loadCallback, this.language);
+        this.renderer = new ArticleRenderer(
+            document.getElementById("wikipedia-frame"),
+            this.pageCallback,
+            !this.isScroll && this.showPreview,
+            !this.isScroll && this.hidePreview,
+            this.loadCallback,
+            this.language,
+            this.revisionDate);
         await this.renderer.loadPage(this.startArticle);
 
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -39,11 +39,13 @@
     <div>
         <h3 class="mb-4">Welcome<span v-cloak v-if="username"> back</span> to Wikipedia Speedruns<span  v-cloak v-if="username">, [[username]]</span>!</h3>
 
-        <div class="alert alert-warning" v-cloak role="alert" v-html="streakText" v-if="loggedIn && streakText"></div>
-
-        <div class="alert alert-info" v-cloak role="alert" v-if="loggedIn">
-            We've just added <b>achievements</b> to the game! Visit your profile page <a v-bind:href="'/profile/' + username">here</a> to check your current progress.
+        <!---->
+        <div class="alert alert-info" v-cloak role="alert" v-if="new Date() < new Date('2023-01-31')">
+            We've noticed some users have been editing articles on Wikipedia to add links. <b>These edits no longer affect our site.</b> Each article
+            will be based on a snapshot of the Wikipedia article from before the prompt is created.
         </div>
+
+        <div class="alert alert-warning" v-cloak role="alert" v-html="streakText" v-if="loggedIn && streakText"></div>
 
         <p>The rules of this game are simple. You'll be given a starting Wikipedia article and an ending Wikipedia article. Your goal is to navigate from the starting article to the ending article using only the article links.</p>
         <p>Some other things to keep in mind:</p>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -22,12 +22,6 @@
             </small>
         </p>
 
-        <div class="alert alert-info" role="alert">
-                Notice the change? Let us know what you think on the  <a href="https://discord.gg/mNYeB9c9db" target="_blank">discord</a>
-                or by emailing us at <a href="mailto:support@wikispeedruns.com">support@wikispeedruns.com</a>.
-
-        </div>
-
         <div class="card">
             <div class="row">
                 <div class="col-8" style="padding-right:0">

--- a/templates/play.html
+++ b/templates/play.html
@@ -43,12 +43,6 @@
                             Time Elapsed<br><strong>[[elapsed.toFixed(3)]] s</strong>
                         </div>
 
-                            <!-- COMMENTING OUT FOR NOW, IN CASE WE NEED IT IN THE FUTURE FOR WHEN WE DO PERSONAL LEADERBOARDS
-                            <div v-if="promptRated" class="col-sm-auto text-nowrap pe-8 py-2">
-                                Mode: <br>
-                                <b class="text-danger" v-if="!promptPlayed && promptActive">Rated</b>
-                                <b v-else>Practice</b>
-                            </div>-->
 
                         <div class="col-sm-auto  text-nowrap py-2 mr-auto">
                             <button @click="expandedTimebox = !expandedTimebox"


### PR DESCRIPTION
This change uses the release date of the Prompt of the day (i.e. `active_start`) as a date to query revisions from wikipedia from. Specifically, we take the most recent query before `active_start` datetime. This applies to all articles in a sprint. If we want to add the same functionality to lobby prompts, we would need a creation datetime.

I also cleaned up some old announcements and added a new one shaming people for editing wikipedia.

As an example, the follow page had some [edits ](https://en.wikipedia.org/w/index.php?title=Witold_Lutos%C5%82awski&diff=1135506581&oldid=1133531527) on Jan 25:
 
![image](https://user-images.githubusercontent.com/11544076/214478916-f8cc217c-6d5b-4bc0-8eca-9966deb5ac88.png)

In my local instance, I added a prompt released on Jan 23 and the edits are gone:

![image](https://user-images.githubusercontent.com/11544076/214479227-0facf871-b32f-467b-88bc-11982526439c.png)

