### PR TITLE
Forbid users from searching with Ctrl+G

### DIFF
--- a/static/js/pages/marathon.js
+++ b/static/js/pages/marathon.js
@@ -300,7 +300,7 @@ window.onbeforeunload = function() {
 // Disable find hotkeys, players will be given a warning
 window.addEventListener("keydown", function(e) {
     //disable find
-    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && e.keyCode == 70)) {
+    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && (e.keyCode == 70 || e.keyCode == 71))) {
         e.preventDefault();
         this.alert("WARNING: Attempt to Find in page. This will be recorded.");
     }

--- a/static/js/pages/play.js
+++ b/static/js/pages/play.js
@@ -315,7 +315,7 @@ let app = new Vue({
 // Disable find hotkeys, players will be given a warning
 window.addEventListener("keydown", function(e) {
     //disable find
-    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && e.keyCode == 70)) {
+    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && (e.keyCode == 70 || e.keyCode == 71))) {
         e.preventDefault();
         this.alert("WARNING: Attempt to Find in page. This will be recorded.");
     }

--- a/static/js/pages/tutorial.js
+++ b/static/js/pages/tutorial.js
@@ -424,7 +424,7 @@ window.addEventListener("beforeunload", beforeUnloadListener);
 // Disable find hotkeys, players will be given a warning
 window.addEventListener("keydown", function(e) {
     //disable find
-    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && e.keyCode == 70)) {
+    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && (e.keyCode == 70 || e.keyCode == 71))) {
         e.preventDefault();
         this.alert("WARNING: Attempt to Find in page. This will be recorded.");
     }


### PR DESCRIPTION
In Firefox and Chrome (and probably other browsers), you can search a page with Ctrl+G, and this is not detected by wikispeedruns. 

I believe that I have fixed this.