### PR TITLE
various admin QOL/management tools

### DIFF
--- a/apis/sprints_api.py
+++ b/apis/sprints_api.py
@@ -146,3 +146,16 @@ def get_prompt(id):
         return "You must be logged in to play this daily prompt", 401
 
     return prompt
+
+
+@sprint_api.get('/check_runs/<int:id>')
+@check_admin
+def check_if_prompt_has_runs(id):
+    return {'has_runs': prompts.check_if_prompt_has_runs(id, "sprint")}
+
+@sprint_api.delete('/clear_runs/<int:id>')
+@check_admin
+def clear_runs(id):
+    prompts.clear_runs_for_prompt(id, "sprint")
+    return "Cleared prompts", 200
+

--- a/apis/sprints_api.py
+++ b/apis/sprints_api.py
@@ -39,6 +39,17 @@ def delete_prompt(id):
             return "Could not delete prompt, may already have run(s)", 400
     except prompts.PromptNotFoundError:
         return "Prompt {id} not found!", 404
+    
+@sprint_api.patch('/set_unused/<id>')
+@check_admin
+def set_prompt_as_unused(id):
+    try:
+        if prompts.set_prompt_as_unused(id, "sprint"):
+            return "Prompt set to unused!", 200
+        else:
+            return "Could not set prompt as unused, check server response", 400
+    except prompts.PromptNotFoundError:
+        return "Prompt {id} not found!", 404
 
 @sprint_api.patch('/<id>')
 @check_admin

--- a/static/js/pages/admin/manage.js
+++ b/static/js/pages/admin/manage.js
@@ -533,5 +533,39 @@ var app = new Vue({
             }
         },
 
+        async autoPopulate() {
+            let empty_days = []
+
+            this.weeks.forEach((week) => {
+                week['days'].forEach((day) => {
+                    if (day['prompts'].length == 0) {
+                        empty_days.push(day['date']);
+                    }
+                });
+            });
+
+            let unused = this.unused.map((x) => x);
+
+            while (empty_days.length > 0 && unused.length > 0) {
+                let day = empty_days.shift()
+                let p = unused.shift()
+                await this.moveToDay(p['prompt_id'], day, day, true)
+            }
+            
+            await this.getPrompts();
+        },
+
+        async moveToDay(prompt_id, start, end, rated) {
+            const response = await fetchJson("/api/sprints/" + prompt_id, "PATCH", {
+                "startDate": start,
+                "endDate": end,
+                "rated": rated,
+            });
+
+            if (response.status != 200) {
+                alert(await response.text());
+            }
+        }
+
     } // End methods
 }); // End vue

--- a/static/js/pages/admin/manage.js
+++ b/static/js/pages/admin/manage.js
@@ -18,10 +18,22 @@ Vue.component('prompt-item', {
     methods: {
 
         async deletePrompt() {
-            const resp = await fetchJson("/api/sprints/" + this.prompt.prompt_id, "DELETE");
+            const resps = await (await fetchJson("/api/sprints/check_runs/" + this.prompt.prompt_id)).json();
 
+            if (resps['has_runs']) {
+                if (confirm("Prompt " + String(this.prompt.prompt_id) + " has runs. Delete?")) {
+                    const clear_resp = await fetchJson("/api/sprints/clear_runs/" + this.prompt.prompt_id, "DELETE");
+                    if (clear_resp.status != 200) {
+                        alert(await clear_resp.text())
+                        return
+                    }
+                } else { return }
+            }
+
+            const resp = await fetchJson("/api/sprints/" + this.prompt.prompt_id, "DELETE");
             if (resp.status == 200) this.$emit('delete-prompt')
             else alert(await resp.text())
+            
         },
 
         async removePrompt() {

--- a/static/js/pages/admin/manage.js
+++ b/static/js/pages/admin/manage.js
@@ -7,7 +7,7 @@ import { MarathonBuilder } from '../../modules/prompts/marathon-submit.js';
 import { SprintBuilder } from '../../modules/prompts/sprint-submit.js';
 
 Vue.component('prompt-item', {
-    props: ['prompt'],
+    props: ['prompt', 'unused'],
 
     data: function() {
         return {
@@ -23,6 +23,13 @@ Vue.component('prompt-item', {
             if (resp.status == 200) this.$emit('delete-prompt')
             else alert(await resp.text())
         },
+
+        async removePrompt() {
+            const resp = await fetchJson("/api/sprints/set_unused/" + this.prompt.prompt_id, "PATCH");
+
+            if (resp.status == 200) this.$emit('remove-prompt')
+            else alert(await resp.text())
+        },
     },
 
     template: (`
@@ -35,6 +42,9 @@ Vue.component('prompt-item', {
 
         <button v-on:click="deletePrompt" type="button" class="btn btn-default">
             <i class="bi bi-trash"></i>
+        </button>
+        <button v-if="!unused" v-on:click="removePrompt" type="button" class="btn btn-default">
+            <i class="bi bi-arrow-counterclockwise"></i>
         </button>
     </li>`)
 });

--- a/templates/admin/manage.html
+++ b/templates/admin/manage.html
@@ -102,8 +102,10 @@
                     <div class="col-sm-6"> <div class="card mb-5"> <div class="card-body">
             
                         <h4> Unused: </h4>
+
+                        <button type="button" class="btn quick-play" v-on:click="autoPopulate">Auto populate [[weeks.length]] weeks</button>
             
-                        <ul>
+                        <ul class="my-3">
                             <prompt-item
                                 v-for="p in unused"
                                 v-bind:prompt="p"
@@ -114,8 +116,6 @@
                             </prompt-item>
                         </ul>
                     </div></div></div>
-            
-            
                 </div>
             
                 <div class="row">

--- a/templates/admin/manage.html
+++ b/templates/admin/manage.html
@@ -109,6 +109,7 @@
                                 v-bind:prompt="p"
                                 v-bind:key="p.prompt_id"
                                 v-on:change="getPrompts"
+                                v-bind:unused="true"
                             >
                             </prompt-item>
                         </ul>
@@ -160,6 +161,7 @@
                                                 v-bind:rated="true"
                                                 v-on:delete-prompt="getPrompts"
                                                 v-on:move-prompt="getPrompts"
+                                                v-on:remove-prompt="getPrompts"
                                             >
                                             </prompt-set>
                                         </td>

--- a/wikispeedruns/prompts.py
+++ b/wikispeedruns/prompts.py
@@ -108,6 +108,29 @@ def delete_prompt(prompt_id: int, prompt_type: PromptType) -> bool:
             return False
 
 
+def set_prompt_as_unused(prompt_id: int, prompt_type: PromptType) -> bool:
+    '''
+    Sets a prompt as unused, returning whether it could be removed. Raises exception on not found
+    '''
+    query = f"""
+    UPDATE {prompt_type}_prompts
+    SET active_start = NULL, active_end = NULL, rated = 0
+    WHERE prompt_id = %s;
+    """
+    
+    db = get_db()
+    with db.cursor() as cursor:
+        try:
+            res = cursor.execute(query, (prompt_id))
+            if (res == 0): raise PromptNotFoundError()
+
+            db.commit()
+            return res == 1
+
+        except pymysql.IntegrityError:
+            return False
+
+
 
 def set_ranked_daily_prompt(prompt_id: int, day: datetime.date) -> bool:
     '''

--- a/wikispeedruns/prompts.py
+++ b/wikispeedruns/prompts.py
@@ -296,3 +296,37 @@ def get_managed_prompts(prompt_type: PromptType) -> List[Prompt]:
     with db.cursor(cursor=DictCursor) as cur:
         cur.execute(query)
         return [compute_visibility(p) for p in cur.fetchall()]
+    
+    
+    
+def check_if_prompt_has_runs(prompt_id: int, prompt_type: PromptType) -> bool:
+    '''
+    Check if prompt has existing runs, returns a boolean
+    '''
+
+    query = f"SELECT COUNT(*) AS n FROM {prompt_type}_runs WHERE prompt_id = %(prompt_id)s"
+    args = {
+        'prompt_id': prompt_id,
+    }
+
+    db = get_db()
+    with db.cursor(cursor=DictCursor) as cur:
+        cur.execute(query, args)
+        n = cur.fetchone()['n']
+        return n > 0
+    
+    
+def clear_runs_for_prompt(prompt_id: int, prompt_type: PromptType):
+    '''
+    Clear existing runs for a prompt
+    '''
+
+    query = f"DELETE FROM {prompt_type}_runs WHERE prompt_id = %(prompt_id)s"
+    args = {
+        'prompt_id': prompt_id,
+    }
+
+    db = get_db()
+    with db.cursor(cursor=DictCursor) as cur:
+        cur.execute(query, args)
+        db.commit()


### PR DESCRIPTION
Added features so far:
- button to move a prompt assigned as POTD already to unused. Currently only working for prompts in the two week window #381 
- allow admins do delete prompts with existing runs. A popup will inform admin that a prompt already has runs, admin will then need to confirm. Deletes all associated runs #393 
- Auto populate POTD button #492