### PR TITLE
Change Stack Overflow to Super User

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ of which can be seen [here](https://github.com/wikispeedruns/wikipedia-speedruns
 Unfortunately, neither celery nor redis are supported on windows. So if you have
 a windows development machine, you will have to run the server through WSL. Note
 that if you want to keep your windows MySQL instance, you need to figure out
-which port the host windows machine is exposed on in WSL. See [this Stack Overflow
+which port the host windows machine is exposed on in WSL. See [this Super User
 post](https://superuser.com/questions/1536619/connect-to-mysql-from-wsl2). Note
 that this changes everytime WSL is restarted.
 


### PR DESCRIPTION
Super User is a question and answer site for computer enthusiasts and power users. This link was pointing to superuser.com, so shouldn't we clarify about where the user is being taken to?