### PR TITLE
Add end article when share result

### DIFF
--- a/static/js/pages/play_finish.js
+++ b/static/js/pages/play_finish.js
@@ -168,7 +168,7 @@ let app = new Vue({
 
 
         generateResults: function(event) {
-            let resultText = `WikiSpeedruns\n${this.startArticle} > ${this.endArticle}\n${this.path.length - 1} 🖱️\n${(this.playTime)} ⏱️`;
+            let resultText = `WikiSpeedruns\n${this.startArticle} > ${this.isQuickRun ? this.endArticle : ""}\n${this.path.length - 1} 🖱️\n${(this.playTime)} ⏱️`;
             if(this.isQuickRun){
                 let link = `https://wikispeedruns.com/play/quick_play`;
                 link += `?prompt_start=${articleToUrl(this.startArticle)}`;

--- a/static/js/pages/play_finish.js
+++ b/static/js/pages/play_finish.js
@@ -168,7 +168,7 @@ let app = new Vue({
 
 
         generateResults: function(event) {
-            let resultText = `WikiSpeedruns\n${this.startArticle} > ${this.isQuickRun ? this.endArticle : ""}\n${this.path.length - 1} 🖱️\n${(this.playTime)} ⏱️`;
+            let resultText = `WikiSpeedruns\n${this.startArticle} ${this.isQuickRun ? (" -> " + this.endArticle) : ""}\n${this.path.length - 1} 🖱️\n${(this.playTime)} ⏱️`;
             if(this.isQuickRun){
                 let link = `https://wikispeedruns.com/play/quick_play`;
                 link += `?prompt_start=${articleToUrl(this.startArticle)}`;

--- a/static/js/pages/play_finish.js
+++ b/static/js/pages/play_finish.js
@@ -168,7 +168,7 @@ let app = new Vue({
 
 
         generateResults: function(event) {
-            let resultText = `WikiSpeedruns\n${this.startArticle}\n${this.path.length - 1} 🖱️\n${(this.playTime)} ⏱️`;
+            let resultText = `WikiSpeedruns\n${this.startArticle} > ${this.endArticle}\n${this.path.length - 1} 🖱️\n${(this.playTime)} ⏱️`;
             if(this.isQuickRun){
                 let link = `https://wikispeedruns.com/play/quick_play`;
                 link += `?prompt_start=${articleToUrl(this.startArticle)}`;


### PR DESCRIPTION
When we click on "Share run summary", only start article is copied to clipboard. This update add also end article.
From:
```
WikiSpeedruns
United States
4 🖱️
16.687 ⏱️
https://wikispeedruns.com/play/quick_play?prompt_start=United%20States&prompt_end=India&lang=en
```
To:
```
WikiSpeedruns
United States > India
4 🖱️
16.687 ⏱️
https://wikispeedruns.com/play/quick_play?prompt_start=United%20States&prompt_end=India&lang=en
```