### PR TITLE
Add dark mode

### DIFF
--- a/static/js/pages/nav.js
+++ b/static/js/pages/nav.js
@@ -1,7 +1,55 @@
 
 import Vue from 'vue/dist/vue.esm.js';
 
+// getTheme retrieves theme from localStorage
+// returns string of either "dark" or "light"
+function getTheme() {
+    let currentTheme = localStorage.getItem("user-theme");
+    if (currentTheme == "dark") {
+        return "dark";
+    } else {
+        return "light";
+    }
+}
 
+async function setTheme(theme) {
+    var htmlElement = document.querySelector('html');
+
+    // set bootstrap theme to root html div
+    // https://getbootstrap.com/docs/5.3/customize/color-modes/
+    htmlElement.setAttribute('data-bs-theme', theme);
+
+    setWikiTheme(theme);
+}
+
+// theme:string is either 'dark' or 'light'
+async function setWikiTheme(theme) {
+    if (theme == "dark") {
+        var toc = document.querySelector('#toc');
+        if (toc != null) {
+            toc.classList.add("wiki-dark");
+        }
+
+        const allTables = document.querySelector('table');
+        if (allTables != null) {
+            allTables.classList.add("wiki-dark");
+        }
+    } else {
+        var toc = document.querySelector('#toc');
+        if (toc != null) {
+            toc.classList.remove("wiki-dark");
+        }
+
+        const allTables = document.querySelector('table');
+        if (allTables != null) {
+            allTables.classList.remove("wiki-dark");
+        }
+    }
+}
+
+function saveTheme(theme) {
+
+}
 
 var app = new Vue({
     delimiters: ['[[', ']]'],
@@ -24,6 +72,11 @@ var app = new Vue({
         async accountPage(event)
         {
             window.location.href = "/account"
+        },
+        async switchTheme() {
+            let currentTheme = getTheme();
+
+            
         }
     }
 

--- a/static/js/pages/nav.js
+++ b/static/js/pages/nav.js
@@ -81,22 +81,10 @@ var app = new Vue({
             this.username = serverData["username"];
             this.isAdmin = serverData["admin"];
         }
-        setTheme(getTheme());
-    },
 
-    mounted: function() {
-        // console.log('called1')
-        // setTheme(getTheme());
-        // // Current hack of waiting half second and reapplying theme
-        // // TODO: replace with play/marathon code calling setTheme again after wiki page loads
-        // let delayInMilliseconds = 1000;
-        // setTimeout(
-        //     ()=> {
-        //         console.log('called2')
-        //         setTheme(getTheme());
-        //     },
-        //     delayInMilliseconds,
-        // );
+        const theme = getTheme();
+        setTheme(theme);
+        this.theme = theme;
     },
 
     methods: {
@@ -104,7 +92,7 @@ var app = new Vue({
         {
             window.location.href = "/account"
         },
-        switchTheme: () => {
+        switchTheme() {
             let currentTheme = getTheme();
             let newTheme = "";
             if (currentTheme != "dark") {
@@ -116,7 +104,6 @@ var app = new Vue({
             saveTheme(newTheme);
 
             this.theme = newTheme;
-            console.log(this.theme);
         },
         getTheme:() => {
             let currentTheme = localStorage.getItem("user-theme");

--- a/static/js/pages/nav.js
+++ b/static/js/pages/nav.js
@@ -2,6 +2,7 @@
 import Vue from 'vue/dist/vue.esm.js';
 
 // getTheme retrieves theme from localStorage
+//      allowing settings to persist to other pages and from refreshes.
 // returns string of either "dark" or "light"
 function getTheme() {
     let currentTheme = localStorage.getItem("user-theme");
@@ -25,39 +26,53 @@ async function setTheme(theme) {
 // theme:string is either 'dark' or 'light'
 async function setWikiTheme(theme) {
     if (theme == "dark") {
-        var toc = document.querySelector('#toc');
-        if (toc != null) {
-            toc.classList.add("wiki-dark");
-        }
+        // var wikiInsert = document.querySelector('#wikipedia-frame');
+        // wikiInsert.classList.add('wiki-dark');
 
-        const allTables = document.querySelector('table');
-        if (allTables != null) {
-            allTables.classList.add("wiki-dark");
-        }
+
+
+        // var toc = document.querySelector('#toc');
+        // if (toc != null) {
+        //     toc.classList.add("wiki-dark");
+        // }
+
+        // const allTables = document.querySelector('table');
+        // if (allTables != null) {
+        //     allTables.classList.add("wiki-dark");
+        // }
     } else {
-        var toc = document.querySelector('#toc');
-        if (toc != null) {
-            toc.classList.remove("wiki-dark");
-        }
+        // var wikiInsert = document.querySelector('#wikipedia-frame');
+        // wikiInsert.classList.remove('wiki-dark');
 
-        const allTables = document.querySelector('table');
-        if (allTables != null) {
-            allTables.classList.remove("wiki-dark");
-        }
+
+
+        // var toc = document.querySelector('#toc');
+        // if (toc != null) {
+        //     toc.classList.remove("wiki-dark");
+        // }
+
+        // const allTables = document.querySelector('table');
+        // if (allTables != null) {
+        //     allTables.classList.remove("wiki-dark");
+        // }
     }
 }
 
 function saveTheme(theme) {
-
+    localStorage.setItem("user-theme", theme);
 }
 
 var app = new Vue({
     delimiters: ['[[', ']]'],
     el: '#nav',
 
-    data: {
-        username: "",
-        loggedIn: false,
+    data: function() {
+        return {
+            username: "",
+            loggedIn: false,
+            /* Set theme to be reactive so findable by v-if/else */
+            theme: "",
+        }
     },
 
     created: function() {
@@ -66,6 +81,22 @@ var app = new Vue({
             this.username = serverData["username"];
             this.isAdmin = serverData["admin"];
         }
+        setTheme(getTheme());
+    },
+
+    mounted: function() {
+        // console.log('called1')
+        // setTheme(getTheme());
+        // // Current hack of waiting half second and reapplying theme
+        // // TODO: replace with play/marathon code calling setTheme again after wiki page loads
+        // let delayInMilliseconds = 1000;
+        // setTimeout(
+        //     ()=> {
+        //         console.log('called2')
+        //         setTheme(getTheme());
+        //     },
+        //     delayInMilliseconds,
+        // );
     },
 
     methods: {
@@ -73,11 +104,30 @@ var app = new Vue({
         {
             window.location.href = "/account"
         },
-        async switchTheme() {
+        switchTheme: () => {
             let currentTheme = getTheme();
+            let newTheme = "";
+            if (currentTheme != "dark") {
+                newTheme = "dark";
+            } else {
+                newTheme = "light";
+            }
+            setTheme(newTheme);
+            saveTheme(newTheme);
 
-            
+            this.theme = newTheme;
+            console.log(this.theme);
+        },
+        getTheme:() => {
+            let currentTheme = localStorage.getItem("user-theme");
+            console.log(currentTheme);
+            if (currentTheme == "dark") {
+                return "dark";
+            } else {
+                return "light";
+            }
         }
+        
     }
 
 });

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -73,7 +73,7 @@ a:hover, a:hover * {
     display: inline-block;
     min-width: 40%;
     width:auto;
-    background-color: #F8F8F8;
+    background-color: var(--bs-body-bg);
     border: 2px solid #000000 !important;
 
     height: auto;
@@ -89,7 +89,7 @@ a:hover, a:hover * {
     width: 100vw;
     bottom: 0;
     left:0;
-    background-color: #F8F8F8;
+    background-color: var(--bs-body-bg);
     border-top: 3px solid #000000 !important;
 
     padding: 5px 10px;

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -66,7 +66,7 @@ a:hover, a:hover * {
 }
 
 .HUDwrapper-fade {
-    background-image: linear-gradient(#ffffff00, #ffffffbb, #ffffffbb, #ffffff);
+    background-image: linear-gradient(#ffffff00, rgba(var(--bs-body-bg), 0.8), var(--bs-body-bg));
 }
 
 .HUD {

--- a/static/stylesheets/wikipedia-mobile-override.css
+++ b/static/stylesheets/wikipedia-mobile-override.css
@@ -1,0 +1,41 @@
+/* 
+  Override imported wikipedia mobile css by importing this file after the other mobile wikipedia files.
+
+  Used to override the default wikipedia mobile css colors with the bootstrap background colors and font colors. 
+
+  Note this file will have to be periodically updated whenever wikipedia updates their mobile css/site to catch any changes.
+  
+  Examples: https://stackoverflow.com/questions/7641082/how-do-i-get-my-import-stylesheet-to-override-the-main-stylesheet 
+*/
+
+.content .infobox {
+  /* Originally #f8f9fa */
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+.infobox {
+  /* Originally #f8f9fa */
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+
+.wikitable>*>tr>th,.wikitable>tr>th {
+  background-color: var(--bs-body-bg);
+  text-align: center
+}
+
+.dablink,.hatnote,.rellink {
+  background-color: var(--bs-body-bg);
+}
+
+/* 
+  Make a link's brighter
+
+  default wikipedia link dark blue, is too dark against grey background in dark mode.
+  Override with bootstrap link colors.
+*/
+a {
+  color: rgba(var(--bs-link-color-rgb));
+}

--- a/static/stylesheets/wikipedia-vec.css
+++ b/static/stylesheets/wikipedia-vec.css
@@ -1341,7 +1341,11 @@ figure[typeof~="mw:Audio/Frame"] > figcaption {
    * The rules here should only define the layout, not color or typography.
    */
    .wiki-insert body {
-    background-color: #f8f9fa;
+    /* 
+      Overrode original with bootstrap variable
+      background-color: #f8f9fa; 
+    */
+    background-color: var(--bs-body-bg);
     color: #202122;
     overflow-y: scroll;
   }
@@ -2286,7 +2290,8 @@ figure[typeof~="mw:Audio/Frame"] > figcaption {
   /* Thumbnails */
   .wiki-insert div.thumbinner {
     border: 1px solid #c8ccd1;
-    background-color: #f8f9fa;
+    /*  override */
+    background-color: var(--bs-body-bg);
     font-size: 94%;
   }
   .thumbimage {
@@ -2640,7 +2645,11 @@ figure[typeof~="mw:Audio/Frame"] > figcaption {
   }
   .wikitable > tr > th,
   .wikitable > * > tr > th {
-    background-color: #eaecf0;
+    /*
+      Overriden originally: with bootstrap variables 
+      background-color: #eaecf0; 
+    */
+    background-color: var(--bs-body-bg);
     text-align: center;
   }
   .wikitable > caption {

--- a/static/stylesheets/wikipedia-vec.css
+++ b/static/stylesheets/wikipedia-vec.css
@@ -2808,7 +2808,10 @@ figure[typeof~="mw:Audio/Frame"] > figcaption {
   /* Links */
   .wiki-insert a {
     text-decoration: none;
+    /* 
+    Commented out for dark mode
     color: #0645ad;
+    */
     background: none;
   }
   .wiki-insert a:not([href]) {
@@ -2851,7 +2854,8 @@ figure[typeof~="mw:Audio/Frame"] > figcaption {
   .wiki-insert h4,
   .wiki-insert h5,
   .wiki-insert h6 {
-    color: #000;
+    /* Replaced #000 with Bootstrap body color*/
+    color: var(--bs-body-color);
     margin: 0;
     padding-top: 0.5em;
     padding-bottom: 0.17em;

--- a/static/stylesheets/wikipedia.css
+++ b/static/stylesheets/wikipedia.css
@@ -948,3 +948,8 @@ span.mwe-math-mathml-inline {
 .mw-special-Book #coll-downloadbox {
 	display: none;
 }
+
+/* Only activated for dark mode. added to table div's and toc div's */
+.wiki-dark {
+	filter: invert(1) hue-rotate(180deg)!important;
+}

--- a/static/stylesheets/wikipedia.css
+++ b/static/stylesheets/wikipedia.css
@@ -963,11 +963,3 @@ span.mwe-math-mathml-inline {
 	color: var(--bs-body-color);
 	background-color: var(--bs-body-bg);
 } 
-
-/* #wikipedia-frame table {
-	background-color: blue;
-}
-
-#wikipedia-frame #toc {
-	background-color: blue;
-} */

--- a/static/stylesheets/wikipedia.css
+++ b/static/stylesheets/wikipedia.css
@@ -953,3 +953,21 @@ span.mwe-math-mathml-inline {
 .wiki-dark {
 	filter: invert(1) hue-rotate(180deg)!important;
 }
+
+#wikipedia-frame table {
+	color: var(--bs-body-color);
+	background-color: var(--bs-body-bg);
+}
+
+#wikipedia-frame #toc {
+	color: var(--bs-body-color);
+	background-color: var(--bs-body-bg);
+} 
+
+/* #wikipedia-frame table {
+	background-color: blue;
+}
+
+#wikipedia-frame #toc {
+	background-color: blue;
+} */

--- a/templates/base.html
+++ b/templates/base.html
@@ -74,8 +74,9 @@
                         </template>
 
                         <template v-else>
-                            <a class="btn btn-light" href="/register">Register</a>
-                            <a class="btn btn-light" href="/login">Login</a>
+                            <button v-on:click="switchTheme()">Switch Theme</button>
+                            <a class="btn" href="/register">Register</a>
+                            <a class="btn" href="/login">Login</a>
                         </template>
                     </div>
                 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,7 +55,9 @@
                         <li class="nav-item mx-2">
                             <a class="nav-link" v-bind:class="loggedIn ? '': 'text-center'" v-bind:href="'/contribute'">Contribute</a>
                         </li>
-
+                        <button class="btn" v-on:click="switchTheme()">
+                            SwitchTheme
+                        </button>
                         <template v-if="loggedIn">
 
                             <template v-if="isAdmin">
@@ -72,9 +74,7 @@
                                 <button class="btn align-middle my-auto" style="background-color:transparent" v-on:click="accountPage"><i class="bi bi-gear"></i></button>
                             </li>
                         </template>
-
                         <template v-else>
-                            <button v-on:click="switchTheme()">Switch Theme</button>
                             <a class="btn" href="/register">Register</a>
                             <a class="btn" href="/login">Login</a>
                         </template>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,9 +5,9 @@
         <!--Bootstrap stuff-->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.2/font/bootstrap-icons.css">
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
         <script>
             // Gathers all arguments from server into single JS object, argument is rendered as a JSON string by flask

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,7 +56,7 @@
                             <a class="nav-link" v-bind:class="loggedIn ? '': 'text-center'" v-bind:href="'/contribute'">Contribute</a>
                         </li>
                         <button class="btn" v-on:click="switchTheme()">
-                            SwitchTheme
+                            [[(theme === "dark") ? "Light Mode" : "Dark Mode"]]
                         </button>
                         <template v-if="loggedIn">
 

--- a/templates/play.html
+++ b/templates/play.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="https://meta.wikimedia.org/api/rest_v1/data/css/mobile/base" media="screen and (max-width: 767px)">
 <link rel="stylesheet" href="https://en.wikipedia.org/api/rest_v1/data/css/mobile/site" media="screen and (max-width: 767px)">
 <link rel="stylesheet" href="https://meta.wikimedia.org/api/rest_v1/data/css/mobile/pcs" media="screen and (max-width: 767px)">
+<link rel="stylesheet" href="{{url_for('static', filename='stylesheets/wikipedia-mobile-override.css')}}" media="screen and (max-width: 768px)">
 
 <!-- play.js stylesheet -->
 <link rel="stylesheet" type= "text/css" href="{{url_for('static', filename='stylesheets/play.css')}}">


### PR DESCRIPTION
Changes
* Updates bootstrap from 5.1.3 to 5.3.2 (For themes)
* Add switch theme button to nav bar. 
* Modified nav.js with switchTheme function and saveTheme (save's the theme locally as a setting). Setting is saved locally using localStorage (going to another computer does not persist the setting).
* Add wikipedia mobile css override file to replace background-color and font color with bootstrap variables (mobile files are referenced externally) 
* Modified wikipedia desktop css file (we have those saved locally) to replace background-color and font color with bootstrap variables

Other notes
* Tried using media preference (prefers-color-scheme) for inferring theme but didn't seem to work properly and no one has that setting anyways on desktop.
* Maybe in the future could be saved server side in sql table.
* For inverting colors, another alternative was to use "filter: invert(1) hue-rotate(180deg)!important;" on the wiki-insert div but ran into trouble since currently partially use bootstrap css in addition to the wikipedia css so could not cleanly invert all colors.
* Tried adding button as a toggle or sun/moon symbol but ran into trouble with jinga/vue maybe for next pr