### PR TITLE
added an archives page for marathon

### DIFF
--- a/apis/marathon_api.py
+++ b/apis/marathon_api.py
@@ -124,26 +124,16 @@ def get_all_marathon_prompts():
 
 
 @marathon_api.get('/get_prompts')
-def get_marathon_prompts():
+def get_marathon_prompts():    
+    try:
+        limit = int(request.args.get('limit', 5))
+        marathons, _ = prompts.get_archive_prompts("marathon",
+            limit=limit)
 
-    limit = int(request.args.get('limit', 5))
+        return jsonify(marathons)
 
-    args = {'p_limit': limit}
-
-    query = """
-    SELECT prompt_id, start, initcheckpoints, checkpoints, cmty_added_by, cmty_anonymous, cmty_submitted_time, username FROM marathonprompts
-    LEFT JOIN users
-    ON users.user_id = marathonprompts.cmty_added_by
-    ORDER BY prompt_id DESC
-    LIMIT %(p_limit)s
-    """
-
-    db = get_db()
-    with db.cursor(cursor=DictCursor) as cursor:
-        cursor.execute(query, args)
-        results = cursor.fetchall()
-
-        return jsonify(results)
+    except ValueError:
+        return "Invalid limit", 400
 
 
 @marathon_api.get('/prompt/<id>')

--- a/static/js/modules/game/marathon/marathonPrompts.js
+++ b/static/js/modules/game/marathon/marathonPrompts.js
@@ -88,7 +88,7 @@ var MarathonPrompts = {
                 </template>
             </div>
             <div class="card-footer text-muted">
-                Save your runs to continue later.
+                Save your runs to continue later. Want more? Check out our <b><a href="/marathon_archive" class="no-color">archive</a></b>.
             </div>
         </div>
     `)

--- a/static/js/pages/home.js
+++ b/static/js/pages/home.js
@@ -27,7 +27,7 @@ async function getBackupPrompts()
 
 async function getMarathonPrompts()
 {
-    const response = await fetch("/api/marathon/all");
+    const response = await fetch("/api/marathon/get_prompts?limit=5");
     return await response.json();
 }
 

--- a/static/js/pages/marathon_archive.js
+++ b/static/js/pages/marathon_archive.js
@@ -1,0 +1,78 @@
+import Vue from 'vue/dist/vue.esm.js';
+
+import { getLocalMarathons } from "../modules/localStorage/localStorageMarathon.js";
+
+
+/* This really would be better if we had a SPA huh */
+
+const limit = serverData['limit'];
+const offset = serverData['offset'];
+
+var app = new Vue({
+    delimiters: ['[[', ']]'],
+    el: '#app',
+    data: {
+        prompts: [],
+        page: 0,
+        numPages: 0,
+
+        limit: limit,
+        offset: offset,
+        loggedIn: false,
+        username: null,
+        savedGames: [],
+    },
+
+    methods : {
+        runReplay: function(event) {
+            console.log(event)
+        }
+    },
+
+    created: async function() {
+        this.loggedIn = "username" in serverData;
+        if (this.loggedIn) {this.username = serverData['username']}
+        
+        const response = await fetch(`/api/marathon/archive?limit=${limit}&offset=${offset}`);
+        const resp = await response.json();
+
+        this.prompts = resp['prompts'];
+
+        this.numPages = Math.ceil(resp['numPrompts'] / limit);
+        this.page = Math.floor(1 + offset / limit);
+
+        this.limit = limit;
+        this.offset = offset;
+
+        if (!this.loggedIn) {
+
+            const localMarathons = getLocalMarathons();
+
+            for (let prompt of this.prompts){
+                for (let run_id of Object.keys(localMarathons)) {
+                    if (parseInt(localMarathons[run_id].prompt_id) === prompt.prompt_id) {
+                        prompt.played = true
+                    }
+                }
+            }
+        }
+
+        let keys = Object.keys(localStorage),
+        i = keys.length;
+
+        while ( i-- ) {
+            if ( keys[i].substring(0, 5) == 'WS-M-') {
+                this.savedGames.push( JSON.parse(localStorage.getItem(keys[i])) );
+            }
+        }
+        for (let prompt of this.prompts) {
+            prompt.savedGamePresent = false
+            for (let savedGame of this.savedGames) {
+                if (parseInt(savedGame.prompt_id) === prompt.prompt_id) {
+                    prompt.savedGamePresent = true
+                }
+            }
+        }
+
+    }
+})

--- a/templates/marathon_archive.html
+++ b/templates/marathon_archive.html
@@ -1,0 +1,98 @@
+{% extends 'base.html' %}
+
+{% block head %}
+<script defer type='module' src="{{url_for('static', filename='js-build/marathon_archive.js') }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
+{% endblock %}
+
+{% block content %}
+
+<div id="app">
+
+    <h3>Marathon Archive</h3>
+    <div class="row justify-content-md-center">
+
+    <div class="col-md-12">
+
+        <div class="card">
+            <div class="card-body">
+                <div class="table-responsive">
+
+                    <p v-if="username">Check your marathon run history <a v-bind:href="'/marathonruns/' + username">here</a>.</p>
+
+                    <table class="table table-hover">
+                        <thead>
+                            <th scope="col"><a v-on:click="toggleSort('prompt')">Prompt # </a></th>
+                            <th scope="col">Starting Article</th>
+                            <th scope="col">Initial Checkpoints</th>
+                            <th scope="col">Created By</th>
+                            <th class="text-center" scope="col">Played</th>
+                            <th></th>
+                        </thead>
+                        <tbody>
+                            <tr v-for="prompt in prompts" v-cloak>
+                                <td>[[prompt.prompt_id]] </td>
+                                <td>[[prompt.start]]</td>
+                                <td>[[prompt.initcheckpoints]]</td>
+                                <td>
+                                    <template v-if="prompt.username && prompt.cmty_anonymous">
+                                        <small>Anon User</small>
+                                    </template>
+                                    <template v-else-if="prompt.username">
+                                        <small>[[prompt.username]]</small>
+                                    </template>
+                                    <template v-else>
+                                        <small>WS Team</small>
+                                    </template>
+                                </td>
+                                <td class="text-center">
+                                    <span v-if="prompt.played"><i class="bi bi-check-lg"></i></span>
+                                    <span v-else><i class="bi bi-dash-lg"></i></span>
+                                </td>
+                                <td>
+                                    <a v-bind:href="'/play/marathon/' + prompt.prompt_id" v-if="!prompt.savedGamePresent">Play</a>
+                                    <a v-bind:href="'/play/marathon/' + prompt.prompt_id + '?load_save=1'" v-else>Continue</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+
+            <div v-cloak class="card-footer text-center">
+                <a class="btn btn-outline-secondary" role="button"
+                    v-bind:href="'?limit=' + (limit) + '&offset=0'"
+                    v-bind:class="{invisible: page === 1}">
+
+                    <i class="bi bi-chevron-double-left"></i>
+                </a>
+
+                <a class="btn btn-outline-secondary" role="button"
+                    v-bind:href="'?limit=' + limit + '&offset=' + (offset - limit)"
+                    v-bind:class="{invisible: page === 1}">
+
+                    <i class="bi bi-chevron-left" id="prev-page"></i>
+                </a>
+
+                <span>Page <strong>[[page]]</strong> of [[numPages]] </span>
+
+                <a class="btn btn-outline-secondary" role="button"
+                    v-bind:href="'?limit=' + limit + '&offset=' + (offset + limit)"
+                    v-bind:class="{invisible: page === numPages}">
+
+                    <i class="bi bi-chevron-right"></i>
+                </a>
+
+                <a class="btn btn-outline-secondary" role="button"
+                    v-bind:href="'?limit=' + (limit) + '&offset=' + ((numPages - 1) * limit)"
+                    v-bind:class="{invisible: page === numPages}">
+
+                    <i class="bi bi-chevron-double-right"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/views.py
+++ b/views.py
@@ -42,6 +42,15 @@ def get_archive_page():
         return render_with_data('archive.html', limit=limit, offset=offset)
     except ValueError:
         return "Page Not Found", 404
+    
+@views.route('/marathon_archive', methods=['GET'])
+def get_marathon_archive_page():
+    try:
+        limit = int(request.args.get('limit', 10))
+        offset = int(request.args.get('offset', 0))
+        return render_with_data('marathon_archive.html', limit=limit, offset=offset)
+    except ValueError:
+        return "Page Not Found", 404
 
 @views.route('/random', methods=['GET'])
 def get_random_prompt():

--- a/wikispeedruns/prompts.py
+++ b/wikispeedruns/prompts.py
@@ -198,7 +198,7 @@ def _construct_prompt_user_query(prompt_type: PromptType, user_id: Optional[int]
         prompt_type = "sprint_"
         fields = ['p.prompt_id', 'start', 'end', 'rated', 'active_start', 'active_end', 'username']
     elif prompt_type == "marathon":
-        fields = ['p.prompt_id', 'start', 'initcheckpoints', 'checkpoints']
+        fields = ['p.prompt_id', 'start', 'initcheckpoints', 'checkpoints', 'username']
 
     fields += ['cmty_added_by', 'cmty_anonymous', 'cmty_submitted_time']
 
@@ -256,9 +256,6 @@ def get_archive_prompts(prompt_type: PromptType, user_id: Optional[int]=None, of
     '''
     Get all prompts for archive, including currently active
     '''
-    #if (prompt_type == "sprint"):
-    #    query = "SELECT prompt_id, start, end, rated, active_start, active_end, cmty_added_by, cmty_anonymous, cmty_submitted_time, username FROM sprint_prompts"
-    # elif (prompt_type == "marathon")
 
     query, args = _construct_prompt_user_query(prompt_type, user_id)
     if (prompt_type == "sprint"):

--- a/wikispeedruns/prompts.py
+++ b/wikispeedruns/prompts.py
@@ -191,14 +191,21 @@ def _construct_prompt_user_query(prompt_type: PromptType, user_id: Optional[int]
 
     # 1. Determine which fields are needed
     # if prompt_type == marathon probably change these fields
-    fields = ['p.prompt_id', 'start', 'end', 'rated', 'active_start', 'active_end',
-              'cmty_added_by', 'cmty_anonymous', 'cmty_submitted_time', 'username']
+    
     args = {}
+
+    if prompt_type == "sprint": 
+        prompt_type = "sprint_"
+        fields = ['p.prompt_id', 'start', 'end', 'rated', 'active_start', 'active_end', 'username']
+    elif prompt_type == "marathon":
+        fields = ['p.prompt_id', 'start', 'initcheckpoints', 'checkpoints']
+
+    fields += ['cmty_added_by', 'cmty_anonymous', 'cmty_submitted_time']
 
     if user_id:
         fields.append('played')
 
-    query = f"SELECT {','.join(fields)} FROM {prompt_type}_prompts AS p"
+    query = f"SELECT {','.join(fields)} FROM {prompt_type}prompts AS p"
     
     query += f"""
     LEFT JOIN users
@@ -208,10 +215,10 @@ def _construct_prompt_user_query(prompt_type: PromptType, user_id: Optional[int]
     # 2. Add neccesary join/args for user info (TODO could in the future get best run?)
     if user_id:
         # TODO returns null on no plays?
-        query += '''
+        query += f'''
         LEFT JOIN  (
             SELECT prompt_id, COUNT(*) AS played
-            FROM sprint_runs AS runs
+            FROM {prompt_type}runs AS runs
             WHERE user_id=%(user_id)s
             GROUP BY prompt_id
         ) user_runs
@@ -249,12 +256,17 @@ def get_archive_prompts(prompt_type: PromptType, user_id: Optional[int]=None, of
     '''
     Get all prompts for archive, including currently active
     '''
-    if (prompt_type == "sprint"):
-        query = "SELECT prompt_id, start, end, rated, active_start, active_end, cmty_added_by, cmty_anonymous, cmty_submitted_time, username FROM sprint_prompts"
+    #if (prompt_type == "sprint"):
+    #    query = "SELECT prompt_id, start, end, rated, active_start, active_end, cmty_added_by, cmty_anonymous, cmty_submitted_time, username FROM sprint_prompts"
     # elif (prompt_type == "marathon")
 
     query, args = _construct_prompt_user_query(prompt_type, user_id)
-    query += f" WHERE used = 1 AND active_start <= NOW() ORDER BY active_start DESC, prompt_id DESC LIMIT %(offset)s, %(limit)s"
+    if (prompt_type == "sprint"):
+        query += f" WHERE used = 1 AND active_start <= NOW() ORDER BY active_start DESC, prompt_id DESC LIMIT %(offset)s, %(limit)s"
+        count_query = "SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW()"
+    elif (prompt_type == "marathon"):
+        query += f" ORDER BY prompt_id DESC LIMIT %(offset)s, %(limit)s"
+        count_query = "SELECT COUNT(*) AS n FROM marathonprompts"
 
     args["offset"] = offset
     args["limit"] = limit
@@ -266,12 +278,13 @@ def get_archive_prompts(prompt_type: PromptType, user_id: Optional[int]=None, of
         prompts = cur.fetchall()
 
         # remove end prompt from currently active prompts
-        for p in prompts:
-            compute_visibility(p)
-            if (p['active']): p['end'] = None
+        if (prompt_type == "sprint"):
+            for p in prompts:
+                compute_visibility(p)
+                if (p['active']): p['end'] = None
 
         # get the total number of prompts
-        cur.execute("SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW()")
+        cur.execute(count_query)
         n = cur.fetchone()['n']
 
         return prompts, n


### PR DESCRIPTION
- added an archives page for marathons, nearly a carbon copy of the sprints archive. It also uses the limit/offset pagination. Default limit of prompts on a page of the archive is 10 (as opposed to the 20 for sprints)
- reduced featured list size on home page to 5. It will only show the most recent 5 (sorted by prompt id)
![image](https://github.com/wikispeedruns/wikipedia-speedruns/assets/61032765/2939d82b-1077-4a6a-a75a-b4fb048a66dc)
- marathon archive will also check for saved games. If there is a saved game for a prompt, the play link will be "continue" to continue saved game instead. 
![image](https://github.com/wikispeedruns/wikipedia-speedruns/assets/61032765/a30fd2b6-e634-4901-a922-4adc5b3275d4)
- Mobile looks the same as the home menu table. 