### PR TITLE
added gallery box rules

### DIFF
--- a/static/stylesheets/play.css
+++ b/static/stylesheets/play.css
@@ -198,3 +198,13 @@ canvas,
 svg {
   max-width: 100%;
 }
+
+li.gallerybox {
+    vertical-align: top;
+    display: inline-block;
+}
+
+li.gallerybox div.thumb {
+    text-align: center;
+    margin: 2px;
+}


### PR DESCRIPTION
![image](https://github.com/wikispeedruns/wikipedia-speedruns/assets/61032765/20d28368-058e-4b1c-bb8e-a668d25c8d36)

Added gallery box rules so images don't show as list items. See linked issue for what the previous formatting looked like

Interestingly, before this fix, the wikipedia mobile css seems to be working fine for us, but the desktop css was missing these rules.  Wondering if there's anything significantly different between how we handle mobile vs. desktop css loading. 