### PR TITLE
changed quick-play-suggestions ref

### DIFF
--- a/static/js/modules/customPlay.js
+++ b/static/js/modules/customPlay.js
@@ -138,7 +138,7 @@ var CustomPlay = {
 
             <details>
                 <summary>Recommended Prompts</summary>
-                <quick-play-suggestions ref="pg"></quick-play-suggestions>
+                <quick-play-suggestions ref="qps"></quick-play-suggestions>
             </details>
         </div>
     `)


### PR DESCRIPTION
The quick play suggestions had the same ref as the prompt generator, preventing this.$refs.pg.generatePrompt() from working. 