### PR TITLE
added check duplicate prompt checks in sprint builder

### DIFF
--- a/apis/sprints_api.py
+++ b/apis/sprints_api.py
@@ -159,3 +159,12 @@ def clear_runs(id):
     prompts.clear_runs_for_prompt(id, "sprint")
     return "Cleared prompts", 200
 
+@sprint_api.post('/check_duplicate')
+@check_request_json({"start": str, "end": str})
+def check_duplicate_prompt():
+    start = request.json.get('start')
+    end = request.json.get('end')
+
+    res = prompts.check_for_sprint_duplicates(start, end)
+    return jsonify(res)
+

--- a/static/js/modules/prompts/sprint-submit.js
+++ b/static/js/modules/prompts/sprint-submit.js
@@ -44,6 +44,7 @@ var SprintBuilder = {
                 const check_res = await this.checkDuplicates(start_title, end_title);
                 if (check_res[0] != 'none') {
                     var b = "This prompt is already an active prompt, in the prompt queue, or waiting for approval. "
+                    b += this.admin ? ` ${check_res[0]} ${check_res[1]}` : ""
                     if (!this.admin || (this.admin && !confirm(b + " Do you want to submit it anyway?"))) {
                         this.articleCheckMessage = b + " Please try a different prompt."
                         return;

--- a/static/js/modules/prompts/sprint-submit.js
+++ b/static/js/modules/prompts/sprint-submit.js
@@ -41,6 +41,15 @@ var SprintBuilder = {
             let end_title = resp.body.end
 
             try {
+                const check_res = await this.checkDuplicates(start_title, end_title);
+                if (check_res[0] != 'none') {
+                    var b = "This prompt is already an active prompt, in the prompt queue, or waiting for approval. "
+                    if (!this.admin || (this.admin && !confirm(b + " Do you want to submit it anyway?"))) {
+                        this.articleCheckMessage = b + " Please try a different prompt."
+                        return;
+                    } 
+                } 
+
                 if (this.admin) {
                     await this.submitAsAdmin(start_title, end_title);
                     this.articleCheckMessage = "Prompt submit success. "
@@ -62,6 +71,14 @@ var SprintBuilder = {
             var temp = this.start;
             this.start = this.end;
             this.end = temp;
+        },
+
+        async checkDuplicates(start, end) {
+            const response = await fetchJson("/api/sprints/check_duplicate", "POST", {
+                "start": start,
+                "end": end
+            })
+            return await response.json()
         },
 
         async submitAsAdmin(start, end) {

--- a/wikispeedruns/prompts.py
+++ b/wikispeedruns/prompts.py
@@ -340,3 +340,28 @@ def clear_runs_for_prompt(prompt_id: int, prompt_type: PromptType):
     with db.cursor(cursor=DictCursor) as cur:
         cur.execute(query, args)
         db.commit()
+
+
+def check_for_sprint_duplicates(start: str, end: str) -> Tuple[str, int]:
+
+    potd_query = "SELECT prompt_id FROM sprint_prompts WHERE start=%(start)s AND end=%(end)s"
+    cmty_query = "SELECT pending_prompt_id FROM cmty_pending_prompts_sprints WHERE start=%(start)s AND end=%(end)s"
+    args = {
+            'start': start,
+            'end': end,
+        }
+    
+    db = get_db()
+    with db.cursor(cursor=DictCursor) as cur:
+        cur.execute(potd_query, args)
+        res_potd = cur.fetchone()
+        if res_potd:
+            return ('potd', res_potd['prompt_id'])
+    
+        cur.execute(cmty_query, args)
+        res_cmty = cur.fetchone()
+        if res_cmty:
+            return ('cmty', res_cmty['pending_prompt_id'])
+
+        return ('none', -1)
+


### PR DESCRIPTION
Sprint builder (for both admin and cmty contribute pages) will now check for duplicate prompts in both the sprint prompts table (including both unused and used), as well as the cmty pending prompts table. 

Prompt submission will be rejected if there is a duplicate
![image](https://github.com/wikispeedruns/wikipedia-speedruns/assets/61032765/e613fee2-2785-4255-93b6-91295be22b9d)

Admins will have the option to override and submit a duplicate prompt anyway
![image](https://github.com/wikispeedruns/wikipedia-speedruns/assets/61032765/2dda0270-6640-4fe3-b760-acac3877119e)
