### PR TITLE
Fix Tutorial

### DIFF
--- a/static/js/pages/tutorial.js
+++ b/static/js/pages/tutorial.js
@@ -386,7 +386,15 @@ let app = new Vue({
         // used to only render one version of tutorial
         this.isMobile = window.screen.width < 768;
 
-        this.renderer = new ArticleRenderer(document.getElementById("wikipedia-frame"), this.pageCallback, this.showPreview, this.hidePreview);
+        this.renderer = new ArticleRenderer(
+            document.getElementById("wikipedia-frame"), 
+            this.pageCallback, 
+            this.showPreview, 
+            this.hidePreview,
+            null,
+            "en",
+            "2023-01-01T00:00:00" // Date when this tutorial was made approx.
+        );
 
         this.renderer.loadPage("Walt Whitman");
 


### PR DESCRIPTION
Fixed by adding a revision date. This makes it load noticeably slower, but is probably the best option for longevity. Maybe wikipedia will start caching it for us, or we should build our own caching layer.