### PR TITLE
Add give up button

### DIFF
--- a/frontend/static/js/pages/play.js
+++ b/frontend/static/js/pages/play.js
@@ -318,7 +318,11 @@ let app = new Vue({
             this.milliseconds = 0;
             this.savedMilliseconds = 0;
             this.offset = Date.now();
-        }
+        },
+
+        home: function (event) {
+            window.location.replace("/");
+        },
     }
 })
 

--- a/frontend/templates/play.html
+++ b/frontend/templates/play.html
@@ -44,7 +44,7 @@
                             Time Elapsed<br><strong>[[elapsed.toFixed(3)]] s</strong>
                         </div>
                         <div class="col-sm-auto  text-nowrap py-2 mr-auto">
-                            <button @click="home">Give Up</button>
+                            <button @click="home" class="btn btn-outline-secondary mx-2" style="padding: 8px 8px">Give Up</button>
                         </div>
 
                         <div class="col-sm-auto  text-nowrap py-2 mr-auto">
@@ -76,7 +76,7 @@
                             Time Elapsed: <strong>[[elapsed.toFixed(3)]] s</strong>
                         </div>
                         <div class="col-sm-auto  text-nowrap py-2 mr-auto">
-                            <button @click="home">Give Up</button>
+                            <button @click="home" class="btn btn-outline-secondary mx-2" style="padding: 8px 8px" >Give Up</button>
                         </div>
 
                         <div class="col-sm-auto text-nowrap py-2 mr-auto">
@@ -102,6 +102,10 @@
                         <br>
                         Time Elapsed: <strong>[[elapsed.toFixed(3)]] s</strong>
                     </div>
+                    <div class="col-sm-auto  text-nowrap py-2 mr-auto">
+                        <button @click="home" class="btn btn-outline-secondary"
+                        style="font-size: 0.75rem; padding: 5px 5px" >Give Up</button>
+                    </div>
 
                     <div class="col-auto px-2">
                         <button @click="expandedTimebox = !expandedTimebox"
@@ -119,6 +123,10 @@
                         <small style="cursor: help;" :href="`/wiki/${endArticle}`" @click="showPreview">
                             ⓘ
                         </small>
+                    </div>
+                    <div class="col-sm-auto  text-nowrap py-2 mr-auto">
+                        <button @click="home" class="btn btn-outline-secondary"
+                        style="font-size: 0.75rem; padding: 5px 5px" >Give Up</button>
                     </div>
                     <div class="col-auto px-2">
                         <button @click="expandedTimebox = !expandedTimebox"

--- a/frontend/templates/play.html
+++ b/frontend/templates/play.html
@@ -43,7 +43,9 @@
                         <div class="col text-nowrap px-2 pt-2">
                             Time Elapsed<br><strong>[[elapsed.toFixed(3)]] s</strong>
                         </div>
-
+                        <div class="col-sm-auto  text-nowrap py-2 mr-auto">
+                            <button @click="home">Give Up</button>
+                        </div>
 
                         <div class="col-sm-auto  text-nowrap py-2 mr-auto">
                             <button @click="expandedTimebox = !expandedTimebox"
@@ -52,10 +54,12 @@
                                 <i class="bi bi-chevron-down"></i>
                             </button>
                         </div>
+                        
                         <div class="w-100"></div>
                         <div class="col-lg-auto text-nowrap px-4 py-2">
                             Current Article<br><strong>[[currentArticle]]</strong>
                         </div>
+                        
                     </div>
                 </div>
             </div>
@@ -70,6 +74,9 @@
                         </div>
                         <div class="col text-nowrap px-4 pt-2">
                             Time Elapsed: <strong>[[elapsed.toFixed(3)]] s</strong>
+                        </div>
+                        <div class="col-sm-auto  text-nowrap py-2 mr-auto">
+                            <button @click="home">Give Up</button>
                         </div>
 
                         <div class="col-sm-auto text-nowrap py-2 mr-auto">

--- a/frontend/templates/play.html
+++ b/frontend/templates/play.html
@@ -44,7 +44,7 @@
                             Time Elapsed<br><strong>[[elapsed.toFixed(3)]] s</strong>
                         </div>
                         <div class="col-sm-auto  text-nowrap py-2 mr-auto">
-                            <button @click="home" class="btn btn-outline-secondary mx-2" style="padding: 8px 8px">Give Up</button>
+                            <button @click="home" class="btn btn-outline-secondary mx-2" style="padding: 4px 8px">Give Up</button>
                         </div>
 
                         <div class="col-sm-auto  text-nowrap py-2 mr-auto">
@@ -76,7 +76,7 @@
                             Time Elapsed: <strong>[[elapsed.toFixed(3)]] s</strong>
                         </div>
                         <div class="col-sm-auto  text-nowrap py-2 mr-auto">
-                            <button @click="home" class="btn btn-outline-secondary mx-2" style="padding: 8px 8px" >Give Up</button>
+                            <button @click="home" class="btn btn-outline-secondary mx-2" style="padding: 4px 8px" >Give Up</button>
                         </div>
 
                         <div class="col-sm-auto text-nowrap py-2 mr-auto">
@@ -104,7 +104,7 @@
                     </div>
                     <div class="col-sm-auto  text-nowrap py-2 mr-auto">
                         <button @click="home" class="btn btn-outline-secondary"
-                        style="font-size: 0.75rem; padding: 5px 5px" >Give Up</button>
+                        style="font-size: 0.75rem; padding: 2.5px 5px" >Give Up</button>
                     </div>
 
                     <div class="col-auto px-2">
@@ -126,7 +126,7 @@
                     </div>
                     <div class="col-sm-auto  text-nowrap py-2 mr-auto">
                         <button @click="home" class="btn btn-outline-secondary"
-                        style="font-size: 0.75rem; padding: 5px 5px" >Give Up</button>
+                        style="font-size: 0.75rem; padding: 2.5px 5px" >Give Up</button>
                     </div>
                     <div class="col-auto px-2">
                         <button @click="expandedTimebox = !expandedTimebox"


### PR DESCRIPTION
Adds a give up button to return to the home screen during a run. Displays on both collapsed and expanded mode and requires confirmation from the user to prevent misclicks. #505 


![Screenshot 2024-07-06 211534](https://github.com/wikispeedruns/wikipedia-speedruns/assets/12538218/cf6fba28-762f-4932-9c33-637285ec5c00)

