### PR TITLE
Fix dark mode suggestions

### DIFF
--- a/frontend/static/js/modules/autocomplete.js
+++ b/frontend/static/js/modules/autocomplete.js
@@ -130,7 +130,7 @@ var AutocompleteInput = {
                         @mousedown.prevent
                         @mouseover="setHighlightIndex(index)"
                         @click="selectArticle(article)"
-                        :style="{ 'cursor':'pointer', 'background-color': index===highlightIndex ? 'lightgray':'transparent', 'padding':'0' }"
+                        :style="{ 'cursor':'pointer', 'background-color': index===highlightIndex ? 'lightgray':'transparent', 'padding':'0', color: 'black' }"
                     >
                         <h6 style="margin-left: 12px">{{ article }}</h6>
                     </li>

--- a/frontend/static/js/modules/customPlay.js
+++ b/frontend/static/js/modules/customPlay.js
@@ -21,22 +21,14 @@ var CustomPlay = {
 
             language: "en",
             languages: [],
-
-            theme: ""
         }
 	},
 
     mounted() {
         this.getLanguages();
-        this.getTheme();
     },
 
     methods: {
-
-        getTheme() {
-            var htmlElement = document.querySelector('html');
-            this.theme = htmlElement.getAttribute("data-bs-theme");
-        },
 
         async getLanguages() {
             this.languages = await getSupportedLanguages();

--- a/frontend/static/js/modules/customPlay.js
+++ b/frontend/static/js/modules/customPlay.js
@@ -21,14 +21,22 @@ var CustomPlay = {
 
             language: "en",
             languages: [],
+
+            theme: ""
         }
 	},
 
     mounted() {
         this.getLanguages();
+        this.getTheme();
     },
 
     methods: {
+
+        getTheme() {
+            var htmlElement = document.querySelector('html');
+            this.theme = htmlElement.getAttribute("data-bs-theme");
+        },
 
         async getLanguages() {
             this.languages = await getSupportedLanguages();


### PR DESCRIPTION
Make text suggestions black to fix visual display in dark mode. #537

![Screenshot 2024-07-06 221852](https://github.com/wikispeedruns/wikipedia-speedruns/assets/12538218/3b026123-3505-41b3-acd0-90c7a56cda5d)
