### PR TITLE
fixed a fatal error from penalty mode

### DIFF
--- a/frontend/static/js/pages/play.js
+++ b/frontend/static/js/pages/play.js
@@ -142,7 +142,12 @@ let app = new Vue({
         this.isScroll = IS_SCROLL_ON;
 
         const prompt = await getPrompt(PROMPT_ID, LOBBY_ID);
-	    const lobby = await getLobby(LOBBY_ID);
+
+        this.isPenaltyMode = false;
+        if (LOBBY_ID != null) {
+            const lobby = await getLobby(LOBBY_ID);
+            this.isPenaltyMode = !!lobby["rules"]["is_penalty_mode"];
+        }
 
         this.startArticle = prompt["start"];
         this.endArticle = prompt["end"];
@@ -152,8 +157,6 @@ let app = new Vue({
         this.promptPlayed = !!prompt["played"];
         this.promptActive = !!prompt["active"];
         this.promptRated = !!prompt["rated"];
-	
-	    this.isPenaltyMode = !!lobby["rules"]["is_penalty_mode"];
 
         // Use the release date of teh prompt (if it exists) to determine the article revision
         this.revisionDate = prompt?.["active_start"];


### PR DESCRIPTION
LOBBY ID is null when not in a lobby (ex. POTD), causing a 404 error when accessing the lobby api by null ID