### PR TITLE
temp fix for manage and home page datetime display errors

### DIFF
--- a/frontend/static/js/pages/admin/manage.js
+++ b/frontend/static/js/pages/admin/manage.js
@@ -486,6 +486,12 @@ var app = new Vue({
             let nextDailys = {};
             let nextWeeklys = {};
 
+            prompts.forEach((p) => {
+                if (p["active_start"] === null) {return;}
+                let d = new Date(Date.parse(p["active_start"]));
+                p["active_start"] = d.toISOString();
+            });
+
             daily.forEach((p) => {
                 // Get iso date (yyyy-mm-dd)
                 const key = p["active_start"].substring(0, 10);

--- a/frontend/static/js/pages/home.js
+++ b/frontend/static/js/pages/home.js
@@ -106,7 +106,7 @@ var app = new Vue({
 
         if (this.dailyPrompts.length > 0) {
             // Add Z to indicate UTC format
-            const endTime = new Date(this.dailyPrompts[0]["active_end"] + "Z");
+            const endTime = new Date(Date.parse(this.dailyPrompts[0]["active_end"]));
 
             const timerInterval = setInterval(() => {
                 const now = new Date();


### PR DESCRIPTION
somewhere in the serialization/deserialization of python datetime objects, objects are converted to HTTP date formatted strings instead of ISO8601 formatted strings. This temp fix adds a parsing/conversion step before we use datetimes further on the frontend. 

Related: https://github.com/pallets/flask/issues/1443#issuecomment-95985373