### PR TITLE
Add rule to lobbies to allow Find In Page hotkey

### DIFF
--- a/apis/leaderboard_api.py
+++ b/apis/leaderboard_api.py
@@ -1,4 +1,3 @@
-from lib2to3.pgen2.token import OP
 from flask import Flask, jsonify, request, Blueprint, session
 
 from util.decorators import check_request_json, OptionalArg

--- a/frontend/static/js/pages/lobbys/create.js
+++ b/frontend/static/js/pages/lobbys/create.js
@@ -14,6 +14,7 @@ var app = new Vue({
         competitiveMode: false,
         requireAccount: false,
         penaltyMode: false,
+        findHotkeyMode: false,
     },
 
     methods: {
@@ -29,6 +30,7 @@ var app = new Vue({
             requestBody.rules["require_account"] = this.requireAccount;
             requestBody.rules["is_penalty_mode"] = this.penaltyMode;
             requestBody.rules["live_mode"] = this.liveMode;
+            requestBody.rules["find_hotkey_mode"] = this.findHotkeyMode;
 
             // Only add these fields if not empty
             if (this.name) requestBody["name"] = this.name;

--- a/frontend/templates/lobbys/create.html
+++ b/frontend/templates/lobbys/create.html
@@ -53,7 +53,17 @@
                         Add 20 seconds to time on click
                     </span>
                 </label>
-	    </div>
+	        </div>
+
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="find-hotkey-mode-checkbox" v-model="findHotkeyMode">
+                <label class="form-check-label" for="find-hotkey-mode-checkbox">
+                    <b>Find Hotkey mode</b>
+                    <span class="text-muted fw-light">
+                        Allow players to use Find In Page hotkeys
+                    </span>
+                </label>
+	        </div>
 
             <!--
             <div class="form-check">


### PR DESCRIPTION
Adds a new rule to the lobby creation menu to allow use of the Find In Page hotkey.

The rule is false by default, and does not impact existing lobbies.

<img width="996" alt="image" src="https://github.com/user-attachments/assets/cec2dc09-bcf7-455e-b6b9-07cabab3e7b4" />

<img width="996" alt="image" src="https://github.com/user-attachments/assets/9d52b679-39b5-4bfc-935a-05baf9ca6911" />

_Background: I'm a computer science teacher and I love using this site as an activity for my students! I'd love to be able to help them learn more strategies for reading documentation, including learning how to use cmd+f._