### PR TITLE
[553] Updated CSS to use variable background color for 'toolbox' article preview div

### DIFF
--- a/frontend/static/stylesheets/play.css
+++ b/frontend/static/stylesheets/play.css
@@ -102,7 +102,7 @@
 .tooltip-container {
     width: 360px;
     font-size: 14px;
-    background: white;
+    background: var(--bs-body-bg);
     box-shadow: 0 30px 90px -20px rgba(0, 0, 0, 0.3), 0 0 1px 1px rgba(0, 0, 0, 0.05);
     position: fixed;
     z-index: 10000000;
@@ -136,7 +136,7 @@
     height: 1.5em;
     margin-bottom: 1rem;
     margin-right: 1rem;
-    background-image: linear-gradient(to right, rgba(255, 255, 255, 0), #ffffff 50%);
+    background-image: linear-gradient(to right, rgba(255, 255, 255, 0), var(--bs-body-bg) 50%);
     pointer-events: none;
 }
 


### PR DESCRIPTION
Fix for https://github.com/wikispeedruns/wikipedia-speedruns/issues/553.
Changed to use the variable background color so it will be set correctly regardless of theme. 

Tip for reproducing: Since you can't "inspect" the element because its a popover, you can follow this to be able to inspect: https://stackoverflow.com/questions/17931571/freeze-screen-in-chrome-debugger-devtools-panel-for-popover-inspection

Testing: Ran server locally with changes and confirmed that things worked as expected in both dark mode and light mode. 