### PR TITLE
fix: redirect user to home after password reset (#632)

### DIFF
--- a/frontend/templates/users/reset_password.html
+++ b/frontend/templates/users/reset_password.html
@@ -45,7 +45,7 @@ async function handleReset(event)
     if (response.status == 200) {
         validationAlert("Password Changed", false);
 
-        window.location.href = "/login";
+        window.location.href = "/";
     } else if (response.status == 400) {
         validationAlert("Could not reset password (expired or invalid link)");
     } else {


### PR DESCRIPTION
## Fix: Redirect user to home after password reset (#632)

### Description

This PR addresses [Issue #632](https://github.com/<your-org-or-user>/<repo-name>/issues/632), which describes that after a successful password reset, the user remains on the same page instead of being redirected to the homepage.

### What Has Been Changed

- In the `reset_password.html` template, inside the JavaScript code, the redirect path was updated from:
  
  ```js
  window.location.href = "/login";
