### PR TITLE
Fix username bug 

### DIFF
--- a/apis/users_api.py
+++ b/apis/users_api.py
@@ -307,6 +307,14 @@ def change_username():
     id = session["user_id"]
     new_username = request.json["new_username"]
 
+    # Keep username rules consistent with account creation.
+    if not isinstance(new_username, str) or not new_username:
+        return "Invalid username", 400
+    if len(new_username) > 20:
+        return "Invalid username", 400
+    if not _valid_username(new_username):
+        return "Invalid username", 400
+
     db = get_db()
     with db.cursor(cursor=DictCursor) as cursor:
 
@@ -546,4 +554,3 @@ def delete_account():
         db.commit()
 
     return "User account deleted", 200
-

--- a/frontend/static/js/modules/achievements.js
+++ b/frontend/static/js/modules/achievements.js
@@ -220,7 +220,7 @@ var achievements = {
             let data = null;
 
             if(this.isProfile){ // This is getting all achievements for data
-                const response = await fetch('/api/achievements/user/' + this.username);
+                const response = await fetch('/api/achievements/user/' + encodeURIComponent(this.username));
                 if(response.status != 200){
                     console.log("error fetching achievements for user");
                     return;

--- a/frontend/static/js/modules/game/marathon/finish.js
+++ b/frontend/static/js/modules/game/marathon/finish.js
@@ -33,7 +33,7 @@ var FinishPage = {
 
         //redirect to the corresponding prompt page
         finishPrompt: function(event) {
-            window.location.replace("/marathonruns/" + this.username);
+            window.location.replace("/marathonruns/" + encodeURIComponent(this.username));
         },
 
         //go back to home page

--- a/frontend/static/js/modules/game/marathon/marathonPrompts.js
+++ b/frontend/static/js/modules/game/marathon/marathonPrompts.js
@@ -31,7 +31,7 @@ var MarathonPrompts = {
             </div>
             <div class="card-body table-responsive">
 
-                <p v-if="username">Check your marathon run history <a v-bind:href="'/marathonruns/' + username">here</a>.</p>
+                <p v-if="username">Check your marathon run history <a v-bind:href="'/marathonruns/' + encodeURIComponent(username)">here</a>.</p>
 
                 <table class="table table-hover">
                     <thead>

--- a/frontend/static/js/modules/profileStats.js
+++ b/frontend/static/js/modules/profileStats.js
@@ -43,14 +43,16 @@ var profileStatsTable = {
         async get_data() {
 
             try {
-                let response = await fetch("/api/profiles/" + this.username + "/stats");
+                const encodedUsername = encodeURIComponent(this.username);
+
+                let response = await fetch("/api/profiles/" + encodedUsername + "/stats");
                 if (response.status != 200) {
                     alert(await response.text());
                     window.location.href = "/";
                 }
                 const runs = await response.json();
 
-                response = await fetch("/api/profiles/" + this.username);
+                response = await fetch("/api/profiles/" + encodedUsername);
                 if (response.status != 200) {
                     alert(await response.text());
                     window.location.href = "/";

--- a/frontend/static/js/modules/userDisplay.js
+++ b/frontend/static/js/modules/userDisplay.js
@@ -13,10 +13,10 @@ var UserDisplay = {
         return {
             link: ''
         }
-	},
+    },
 
     mounted: function() {
-        this.link = `/profile/${this.username}`;
+        this.link = `/profile/${encodeURIComponent(this.username)}`;
     },
 
     template: (`

--- a/frontend/static/js/pages/marathon_prompt.js
+++ b/frontend/static/js/pages/marathon_prompt.js
@@ -23,7 +23,7 @@ var app = new Vue({
     methods: {
 
         getRuns: async function(username) {
-            var response = await fetch("/api/marathon/" + username);
+            var response = await fetch("/api/marathon/" + encodeURIComponent(username));
 
             if (response.status == 401) {
                 alert(await response.text());
@@ -50,7 +50,7 @@ var app = new Vue({
         },
 
         buildNewLink: function (page) {
-            let base = "/marathonruns/" + this.username + "?page=" + String(page)
+            let base = "/marathonruns/" + encodeURIComponent(this.username) + "?page=" + String(page)
             if (this.sortMode === 'path') {
                 base += "&sort=path"
             } else if (this.sortMode === 'time') {

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -65,7 +65,7 @@
                             </template>
                             
                             <li class="nav-item mx-2">
-                                <a class="nav-link active" v-bind:href="'/profile/' + username">[[username]]</a>
+                                <a class="nav-link active" v-bind:href="'/profile/' + encodeURIComponent(username)">[[username]]</a>
                             </li>
 
                             <li class="nav-item align-middle my-auto mx-2">

--- a/frontend/templates/marathon_archive.html
+++ b/frontend/templates/marathon_archive.html
@@ -18,7 +18,7 @@
             <div class="card-body">
                 <div class="table-responsive">
 
-                    <p v-if="username">Check your marathon run history <a v-bind:href="'/marathonruns/' + username">here</a>.</p>
+                    <p v-if="username">Check your marathon run history <a v-bind:href="'/marathonruns/' + encodeURIComponent(username)">here</a>.</p>
 
                     <table class="table table-hover">
                         <thead>

--- a/test/test_users.py
+++ b/test/test_users.py
@@ -151,6 +151,14 @@ def test_change_password(client, user, session):
     }).status_code == 200
 
 
+def test_change_username_rejects_invalid(client, cursor, user, session):
+    resp = client.post("/api/users/change_username", json={"new_username": "%"})
+    assert resp.status_code == 400
+
+    cursor.execute("SELECT username FROM users WHERE user_id=%s", (user["user_id"],))
+    assert cursor.fetchone()["username"] == user["username"]
+
+
 
 def test_reset_password(client, mail, cursor, user, session):
     new_password = user["password"] + "2"
@@ -197,7 +205,6 @@ def test_reset_password(client, mail, cursor, user, session):
             "email": user["email"],
             "password": new_password
         }).status_code == 200
-
 
 
 


### PR DESCRIPTION
### Background

Username changes were not applying the same validation rules used during account creation, which allowed invalid usernames to be written through `change_username`. The frontend also builds several profile and marathon URLs by concatenating the raw username into the path, so usernames with reserved characters can break profile stats, achievements, and marathon history pages. This change makes username handling consistent across account updates and username-based routes.

### Change
- Validate `change_username` inputs against the existing username rules before updating the user record.
- URL-encode usernames anywhere the frontend builds profile, achievements, or marathon links and fetches.
- Add coverage for rejecting invalid usernames in `change_username`.

### Test Plan
Verified:
`npm run build`

Suggested follow-up:
`pytest test/test_users.py`
