### PR TITLE
fix: harden Wikipedia fetch failures in gameplay

### DIFF
--- a/frontend/static/js/modules/customPlay.js
+++ b/frontend/static/js/modules/customPlay.js
@@ -38,7 +38,14 @@ var CustomPlay = {
             if (this.language === 'en') {
                 [this[prompt]] = await this.$refs.pg.generatePrompt();
             } else {
-                this[prompt] = await getRandomArticle(this.language);
+                const article = await getRandomArticle(this.language);
+                if (!article) {
+                    this.articleCheckMessage = "Unable to fetch a random article right now. Please try again.";
+                    return;
+                }
+
+                this.articleCheckMessage = "";
+                this[prompt] = article;
             }
         },
 
@@ -73,6 +80,10 @@ var CustomPlay = {
                 } else {
                     start = await getRandomArticle(this.language);
                     end = await getRandomArticle(this.language);
+                    if (!start || !end) {
+                        this.articleCheckMessage = "Unable to fetch random articles right now. Please try again.";
+                        return;
+                    }
                 }
 
                 console.log("start: " + start + " end: " + end);

--- a/frontend/static/js/modules/game/articleRenderer.js
+++ b/frontend/static/js/modules/game/articleRenderer.js
@@ -31,6 +31,10 @@ export class ArticleRenderer {
         const startTime = Date.now();
         let body = null;
 
+        if (this.loadCallback) {
+            this.loadCallback();
+        }
+
         try {
             body = await getArticle(page, isMobile, this.language, this.revisionDate);
         } catch (error) {
@@ -51,10 +55,6 @@ export class ArticleRenderer {
             // that just makes sure the essential functions work. Really, we should try and find the root cause
             // and fix that. However, we have not been able to reproduce it.
             // TODO add some sort of frontend eror montiroing so we can figure it out
-
-            if (this.loadCallback) {
-                this.loadCallback();
-            }
 
             this.frame.innerHTML = body["text"]["*"];
 

--- a/frontend/static/js/modules/wikipediaAPI/util.js
+++ b/frontend/static/js/modules/wikipediaAPI/util.js
@@ -1,3 +1,59 @@
+const WIKIPEDIA_RETRY_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const wikipediaJsonCache = new Map();
+
+// This is an async delay used between retries. Awaiting it does not block the UI thread.
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function getRetryDelayMs(response, attempt) {
+    const retryAfterHeader = response.headers.get("retry-after");
+    const retryAfterSeconds = retryAfterHeader ? parseInt(retryAfterHeader, 10) : NaN;
+    if (!Number.isNaN(retryAfterSeconds) && retryAfterSeconds >= 0) {
+        return retryAfterSeconds * 1000;
+    }
+
+    return 500 * (attempt + 1);
+}
+
+// `retries=2` means up to 3 total attempts. `useCache` reuses identical JSON responses
+// within the current page session for stable lookups like titles and summaries.
+async function fetchWikipediaJson(url, { retries = 2, useCache = true } = {}) {
+    if (useCache && wikipediaJsonCache.has(url)) {
+        return wikipediaJsonCache.get(url);
+    }
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            const response = await fetch(url, { mode: "cors" });
+            if (response.ok) {
+                const body = await response.json();
+                if (useCache) {
+                    wikipediaJsonCache.set(url, body);
+                }
+                return body;
+            }
+
+            console.warn("Wikipedia request failed:", response.status, url);
+
+            if (!WIKIPEDIA_RETRY_STATUSES.has(response.status) || attempt === retries) {
+                return null;
+            }
+
+            await sleep(getRetryDelayMs(response, attempt));
+        } catch (error) {
+            console.warn("Wikipedia request threw:", url, error);
+            if (attempt === retries) {
+                return null;
+            }
+
+            await sleep(500 * (attempt + 1));
+        }
+    }
+
+    return null;
+}
+
 async function getArticle(page, isMobile = false, lang = 'en', revisionDate=null) {
     // Encode to safely handle spaces/quotes in titles for API requests.
     const encodedPage = encodeURIComponent(page);
@@ -16,10 +72,9 @@ async function getArticle(page, isMobile = false, lang = 'en', revisionDate=null
         let revisionurl = `https://${lang}.wikipedia.org/w/api.php?action=query&format=json&origin=*&prop=revisions&redirects=1&titles=${encodedPage}`
             + `&formatversion=2&rvdir=older&rvprop=timestamp|ids&rvlimit=1&rvstart=${encodedRevisionDate}`;
 
-        const resp = await fetch(revisionurl, {mode: "cors"});
-        const body = await resp.json();
+        const body = await fetchWikipediaJson(revisionurl, { retries: 0 });
 
-        if ("error" in body) {
+        if (!body || "error" in body) {
             return null;
         }
 
@@ -35,12 +90,9 @@ async function getArticle(page, isMobile = false, lang = 'en', revisionDate=null
         url += `&page=${encodedPage}`;
     }
 
+    const body = await fetchWikipediaJson(url, { retries: 0 })
 
-
-    const resp = await fetch(url, {mode: "cors"})
-    const body = await resp.json()
-
-    if ("error" in body) {
+    if (!body || "error" in body) {
         return null;
     } else {
         return body["parse"];
@@ -50,15 +102,12 @@ async function getArticle(page, isMobile = false, lang = 'en', revisionDate=null
 async function getArticleTitle(title, lang = 'en') {
     // Use query+redirects for a canonical title without fetching full HTML.
     const encodedTitle = encodeURIComponent(title);
-    const resp = await fetch(
-        `https://${lang}.wikipedia.org/w/api.php?action=query&redirects=1&origin=*&format=json&formatversion=2&titles=${encodedTitle}`, {
-            mode: "cors"
-        }
-    )
-    const body = await resp.json()
+    const body = await fetchWikipediaJson(
+        `https://${lang}.wikipedia.org/w/api.php?action=query&redirects=1&origin=*&format=json&formatversion=2&titles=${encodedTitle}`
+    );
 
     // Guard against missing/invalid responses from the API.
-    if (!body.query || !body.query.pages || !body.query.pages[0]) {
+    if (!body || !body.query || !body.query.pages || !body.query.pages[0]) {
         return null;
     }
     if (body.query.pages[0].missing) return null;
@@ -66,13 +115,14 @@ async function getArticleTitle(title, lang = 'en') {
 }
 
 async function articleCheck(title, lang = 'en') {
-    const resp = await fetch(
+    const body = await fetchWikipediaJson(
         `https://${lang}.wikipedia.org/w/api.php?action=query&origin=*&format=json&prop=pageprops&ppprop=disambiguation&titles=${title}&formatversion=2`,
-        {
-            mode: "cors"
-        }
-    )
-    const body = await resp.json();
+        { useCache: false }
+    );
+
+    if (!body || !body.query || !body.query.pages || !body.query.pages[0]) {
+        return {warning: "Unable to validate that article right now. Please try again."};
+    }
 
     if (body['query']['pages'][0]['ns'] !== 0) {
         return {warning: `ERROR: \'${title}\' is a namespaced article, may be impossible to reach. Please choose a different end article.`}
@@ -122,38 +172,44 @@ async function checkArticles(start, end, lang = 'en') {
 }
 
 async function getArticleSummary(page, lang = 'en') {
-    const resp = await fetch(
-        `https://${lang}.wikipedia.org/api/rest_v1/page/summary/${page}`,
-        {
-            mode: "cors"
-        }
-    )
-    const body = await resp.json()
+    // Summary endpoints still use the page title in the URL path, so encode it first.
+    let decodedPage = page;
+    try {
+        decodedPage = decodeURIComponent(page);
+    } catch (error) {
+        // If the title was already raw or contains a stray `%`, keep the original string.
+    }
+
+    const encodedPage = encodeURIComponent(decodedPage);
+    const body = await fetchWikipediaJson(
+        `https://${lang}.wikipedia.org/api/rest_v1/page/summary/${encodedPage}`
+    );
 
     return body
 }
 
 async function getAutoCompleteArticles(search, lang = 'en', numEntries = 5){
     // https://en.wikipedia.org/w/api.php?action=opensearch&format=json&formatversion=2&search=a&namespace=0&limit=10
-    const resp = await fetch(
-        `https://${lang}.wikipedia.org/w/api.php?action=opensearch&origin=*&format=json&formatversion=2&search=${search}&namespace=0&limit=${numEntries}`,
-        {
-            mode: "cors"
-        }
-    )
-    let body = await resp.json();
+    // Encode user input before adding it to the query string.
+    const encodedSearch = encodeURIComponent(search);
+    let body = await fetchWikipediaJson(
+        `https://${lang}.wikipedia.org/w/api.php?action=opensearch&origin=*&format=json&formatversion=2&search=${encodedSearch}&namespace=0&limit=${numEntries}`,
+        { useCache: false }
+    );
+    if (!body) {
+        return [];
+    }
     body = body[1]; // get the list of araticles
     return body;
 }
 
 async function getSupportedLanguages() {
-    const resp = await fetch(
-        'https://www.mediawiki.org/w/api.php?action=sitematrix&origin=*&format=json&smtype=language&formatversion=2',
-        {
-            mode: "cors"
-        }
-    )
-    let body = await resp.json();
+    let body = await fetchWikipediaJson(
+        'https://www.mediawiki.org/w/api.php?action=sitematrix&origin=*&format=json&smtype=language&formatversion=2'
+    );
+    if (!body) {
+        return [];
+    }
 
     body = body['sitematrix'];
     delete body['count'];
@@ -178,13 +234,13 @@ async function getSupportedLanguages() {
 }
 
 async function getRandomArticle(lang = 'en') {
-    const resp = await fetch(
+    const body = await fetchWikipediaJson(
         `https://${lang}.wikipedia.org/w/api.php?action=query&origin=*&format=json&list=random&formatversion=2&rnnamespace=0&rnlimit=1`,
-        {
-            mode: "cors"
-        }
-    )
-    const body = await resp.json();
+        { useCache: false }
+    );
+    if (!body || !body.query || !body.query.random || !body.query.random[0]) {
+        return null;
+    }
     return body['query']['random'][0]['title'];
 }
 

--- a/frontend/static/js/pages/lobbys/lobby.js
+++ b/frontend/static/js/pages/lobbys/lobby.js
@@ -123,7 +123,14 @@ var app = new Vue({
             if (this.language === 'en') {
                 [this[prompt]] = await this.$refs.pg.generatePrompt();
             } else {
-                this[prompt] = await getRandomArticle(this.language);
+                const article = await getRandomArticle(this.language);
+                if (!article) {
+                    this.addPromptMessage = "Unable to fetch a random article right now. Please try again.";
+                    return;
+                }
+
+                this.addPromptMessage = "";
+                this[prompt] = article;
             }
         },
 


### PR DESCRIPTION
### Background

Recent production reports point to a shared failure mode across gameplay, info previews, and quickplay lookups when Wikipedia requests fail or return unexpected responses. The renderer now surfaces article-load failures instead of soft-locking, but transient upstream failures can still leave players staring at a failed load state, and random prompt generation can silently hang when the Wikipedia API returns nothing. This hotfix hardens the shared Wikipedia fetch path while keeping article load time out of sprint timing.

### Change
- Add a shared Wikipedia JSON fetch helper for non-article lookups so transient `429` and `5xx` responses fail more gracefully instead of cascading into broken previews and quickplay helpers.
- Keep article body loads on a single attempt, but pause the sprint timer as soon as an article load starts so the HUD visibly freezes during page loads and resumed timing still excludes load time.
- Normalize preview summary titles and handle missing random-article responses in custom play and lobby prompt generation so those flows show an error instead of hanging.

### Test Plan
`npm run build`
