### PR TITLE
Add search functionality for the archive page

### DIFF
--- a/apis/sprints_api.py
+++ b/apis/sprints_api.py
@@ -110,15 +110,18 @@ def get_archive_prompts():
     try:
         limit = int(request.args.get('limit', 20))
         offset = int(request.args.get('offset', 0))
+        search = request.args.get('search', '').strip()
         sprints, num_prompts = prompts.get_archive_prompts("sprint",
             offset=offset,
             limit=limit,
-            user_id=session.get("user_id")
+            user_id=session.get("user_id"),
+            search=search
         )
 
         return jsonify({
             "prompts": sprints,
-            "numPrompts": num_prompts
+            "numPrompts": num_prompts,
+            "search": search,
         })
 
     except ValueError:
@@ -167,4 +170,3 @@ def check_duplicate_prompt():
 
     res = prompts.check_for_sprint_duplicates(start, end)
     return jsonify(res)
-

--- a/app/views.py
+++ b/app/views.py
@@ -39,7 +39,8 @@ def get_archive_page():
     try:
         limit = int(request.args.get('limit', 20))
         offset = int(request.args.get('offset', 0))
-        return render_with_data('archive.html', limit=limit, offset=offset)
+        search = request.args.get('search', '').strip()
+        return render_with_data('archive.html', limit=limit, offset=offset, search=search)
     except ValueError:
         return "Page Not Found", 404
     

--- a/frontend/static/js/pages/archive.js
+++ b/frontend/static/js/pages/archive.js
@@ -7,6 +7,7 @@ import { getLocalSprints } from "../modules/localStorage/localStorageSprint.js";
 
 const limit = serverData['limit'];
 const offset = serverData['offset'];
+const appliedSearch = serverData['search'] || '';
 
 var app = new Vue({
     delimiters: ['[[', ']]'],
@@ -19,18 +20,77 @@ var app = new Vue({
         limit: limit,
         offset: offset,
         loggedIn: false,
+        searchInput: appliedSearch,
+        appliedSearch: appliedSearch,
     },
 
     methods : {
         runReplay: function(event) {
             console.log(event)
-        }
+        },
+
+        escapeHtml: function(text) {
+            return String(text)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#39;');
+        },
+
+        escapeRegex: function(text) {
+            return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        },
+
+        highlightMatch: function(text) {
+            const safeText = this.escapeHtml(text ?? '-');
+
+            if (!this.appliedSearch) {
+                return safeText;
+            }
+
+            const pattern = this.escapeRegex(this.appliedSearch);
+            const regex = new RegExp(`(${pattern})`, 'ig');
+            return safeText.replace(regex, '<mark class="archive-highlight">$1</mark>');
+        },
+
+        matchesSearch: function(prompt) {
+            if (!this.appliedSearch) {
+                return false;
+            }
+
+            const searchNeedle = this.appliedSearch.toLowerCase();
+            return (prompt.start || '').toLowerCase().includes(searchNeedle)
+                || (prompt.end || '').toLowerCase().includes(searchNeedle);
+        },
+
+        pageHref: function(nextOffset) {
+            const params = new URLSearchParams({
+                limit: this.limit,
+                offset: Math.max(0, nextOffset),
+            });
+
+            if (this.appliedSearch) {
+                params.set('search', this.appliedSearch);
+            }
+
+            return `?${params.toString()}`;
+        },
     },
 
     created: async function() {
         this.loggedIn = "username" in serverData;
 
-        const response = await fetch(`/api/sprints/archive?limit=${limit}&offset=${offset}`);
+        const params = new URLSearchParams({
+            limit,
+            offset,
+        });
+
+        if (appliedSearch) {
+            params.set('search', appliedSearch);
+        }
+
+        const response = await fetch(`/api/sprints/archive?${params.toString()}`);
         const resp = await response.json();
 
         this.prompts = resp['prompts'];

--- a/frontend/static/stylesheets/main.css
+++ b/frontend/static/stylesheets/main.css
@@ -192,3 +192,25 @@ details[open] summary {
   outline: none;
   box-shadow: none;
 }
+
+html[data-bs-theme="light"] mark.archive-highlight {
+    padding: 0;
+    background-color: #fff3a3;
+    color: inherit;
+    font-weight: 700;
+}
+
+html[data-bs-theme="dark"] mark.archive-highlight {
+    padding: 0;
+    background-color: #fff3a3;
+    color: #000000;
+    font-weight: 700;
+}
+
+html[data-bs-theme="light"] .archive-match-row > * {
+    background-color: rgba(0, 0, 0, 0.04);
+}
+
+html[data-bs-theme="dark"] .archive-match-row > * {
+    background-color: rgba(255, 255, 255, 0.06);
+}

--- a/frontend/templates/archive.html
+++ b/frontend/templates/archive.html
@@ -16,6 +16,31 @@
 
     <div class="col-md-12">
 
+        <form class="card mb-3" action="/archive" method="get">
+            <div class="card-body">
+                <div class="row g-2 align-items-center">
+                    <div class="col-md-8">
+                        <input
+                            class="form-control"
+                            type="search"
+                            name="search"
+                            v-model.trim="searchInput"
+                            placeholder="Search starting or ending article"
+                            aria-label="Search archive prompts"
+                        >
+                    </div>
+                    <input type="hidden" name="limit" v-bind:value="limit">
+                    <input type="hidden" name="offset" value="0">
+                    <div class="col-auto">
+                        <button class="btn btn-primary" type="submit">Search</button>
+                    </div>
+                    <div class="col-auto" v-if="searchInput">
+                        <a class="btn btn-outline-secondary" href="/archive">Clear</a>
+                    </div>
+                </div>
+            </div>
+        </form>
+
         <div class="card">
             <div class="card-body">
                 <div class="table-responsive">
@@ -32,11 +57,12 @@
                             <th></th>
                         </thead>
                         <tbody>
-                            <tr v-for="prompt in prompts" v-cloak>
+                            <template v-for="prompt in prompts">
+                                <tr v-cloak v-bind:class="{'archive-match-row': matchesSearch(prompt)}">
                                 <td>[[prompt.active_start.substring(0, 10)]]</td>
                                 <td>[[prompt.prompt_id]] </td>
-                                <td>[[prompt.start]]</td>
-                                <td>[[prompt.end || '-']]</td>
+                                <td v-html="highlightMatch(prompt.start)"></td>
+                                <td v-html="highlightMatch(prompt.end || '-')"></td>
                                 <td>
                                     <template v-if="prompt.username && prompt.cmty_anonymous">
                                         <small>Anon User</small>
@@ -51,7 +77,8 @@
                                 <td class="text-center"><span v-if="prompt.played"><i class="bi bi-check-lg"></i></span></td>
                                 <td><a v-bind:href="'/play/' + prompt.prompt_id">Play</a></td>
                                 <td><a v-bind:href="'/leaderboard/' + prompt.prompt_id">Results</a></td>
-                            </tr>
+                                </tr>
+                            </template>
                         </tbody>
                     </table>
                 </div>
@@ -60,14 +87,14 @@
 
             <div v-cloak class="card-footer text-center">
                 <a class="btn btn-outline-secondary" role="button"
-                    v-bind:href="'?limit=' + (limit) + '&offset=0'"
+                    v-bind:href="pageHref(0)"
                     v-bind:class="{invisible: page === 1}">
 
                     <i class="bi bi-chevron-double-left"></i>
                 </a>
 
                 <a class="btn btn-outline-secondary" role="button"
-                    v-bind:href="'?limit=' + limit + '&offset=' + (offset - limit)"
+                    v-bind:href="pageHref(offset - limit)"
                     v-bind:class="{invisible: page === 1}">
 
                     <i class="bi bi-chevron-left" id="prev-page"></i>
@@ -76,14 +103,14 @@
                 <span>Page <strong>[[page]]</strong> of [[numPages]] </span>
 
                 <a class="btn btn-outline-secondary" role="button"
-                    v-bind:href="'?limit=' + limit + '&offset=' + (offset + limit)"
+                    v-bind:href="pageHref(offset + limit)"
                     v-bind:class="{invisible: page === numPages}">
 
                     <i class="bi bi-chevron-right"></i>
                 </a>
 
                 <a class="btn btn-outline-secondary" role="button"
-                    v-bind:href="'?limit=' + (limit) + '&offset=' + ((numPages - 1) * limit)"
+                    v-bind:href="pageHref((numPages - 1) * limit)"
                     v-bind:class="{invisible: page === numPages}">
 
                     <i class="bi bi-chevron-double-right"></i>

--- a/test/test_prompts.py
+++ b/test/test_prompts.py
@@ -1,5 +1,8 @@
+import datetime
 import enum
 import pytest
+
+from wikispeedruns import prompts
 
 PROMPTS = [
     {
@@ -22,6 +25,31 @@ def prompt_set(cursor):
     yield
 
     cursor.execute("DELETE FROM sprint_prompts")
+
+
+@pytest.fixture()
+def archive_search_prompt_set(cursor):
+    now = datetime.datetime.now()
+    active_start = now - datetime.timedelta(hours=1)
+    active_end = now + datetime.timedelta(hours=1)
+    expired_start = now - datetime.timedelta(days=2)
+    expired_end = now - datetime.timedelta(days=1)
+
+    query = """
+    INSERT INTO sprint_prompts (start, end, active_start, active_end)
+    VALUES (%s, %s, %s, %s);
+    """
+    cursor.executemany(query, [
+        ("Visible Start Leak Probe", "Hidden End Needle", active_start, active_end),
+        ("Expired Start Needle", "Expired End Needle", expired_start, expired_end),
+    ])
+
+    yield
+
+    cursor.execute(
+        "DELETE FROM sprint_prompts WHERE start IN (%s, %s)",
+        ("Visible Start Leak Probe", "Expired Start Needle"),
+    )
 
 
 def test_create_prompt(client, cursor, admin_session):
@@ -65,3 +93,40 @@ def test_delete_no_admin(client, cursor, prompt_set):
     assert response.status_code == 401
     cursor.execute("SELECT start, end FROM sprint_prompts WHERE prompt_id=%s", (id, ))
     assert cursor.fetchone() == PROMPTS[id]
+
+
+def test_archive_search_does_not_match_active_end(cursor, archive_search_prompt_set):
+    archive_prompts, num_prompts = prompts.get_archive_prompts("sprint", search="Hidden End Needle")
+
+    assert num_prompts == 0
+    assert archive_prompts == []
+
+
+def test_archive_search_matches_active_start_without_revealing_end(cursor, archive_search_prompt_set):
+    archive_prompts, num_prompts = prompts.get_archive_prompts("sprint", search="Visible Start Leak Probe")
+
+    assert num_prompts == 1
+    assert archive_prompts[0]["start"] == "Visible Start Leak Probe"
+    assert archive_prompts[0]["end"] is None
+
+
+def test_archive_search_matches_expired_end(cursor, archive_search_prompt_set):
+    archive_prompts, num_prompts = prompts.get_archive_prompts("sprint", search="Expired End Needle")
+
+    assert num_prompts == 1
+    assert archive_prompts[0]["start"] == "Expired Start Needle"
+    assert archive_prompts[0]["end"] == "Expired End Needle"
+
+
+def test_archive_search_treats_like_wildcards_as_literals(cursor, archive_search_prompt_set):
+    archive_prompts, num_prompts = prompts.get_archive_prompts("sprint", search="%")
+
+    assert num_prompts == 0
+    assert archive_prompts == []
+
+
+def test_archive_search_treats_sql_syntax_as_literal_text(cursor, archive_search_prompt_set):
+    archive_prompts, num_prompts = prompts.get_archive_prompts("sprint", search="' OR 1=1 --")
+
+    assert num_prompts == 0
+    assert archive_prompts == []

--- a/test/test_prompts.py
+++ b/test/test_prompts.py
@@ -99,7 +99,7 @@ def test_archive_search_does_not_match_active_end(cursor, archive_search_prompt_
     archive_prompts, num_prompts = prompts.get_archive_prompts("sprint", search="Hidden End Needle")
 
     assert num_prompts == 0
-    assert archive_prompts == []
+    assert not archive_prompts
 
 
 def test_archive_search_matches_active_start_without_revealing_end(cursor, archive_search_prompt_set):
@@ -122,11 +122,11 @@ def test_archive_search_treats_like_wildcards_as_literals(cursor, archive_search
     archive_prompts, num_prompts = prompts.get_archive_prompts("sprint", search="%")
 
     assert num_prompts == 0
-    assert archive_prompts == []
+    assert not archive_prompts
 
 
 def test_archive_search_treats_sql_syntax_as_literal_text(cursor, archive_search_prompt_set):
     archive_prompts, num_prompts = prompts.get_archive_prompts("sprint", search="' OR 1=1 --")
 
     assert num_prompts == 0
-    assert archive_prompts == []
+    assert not archive_prompts

--- a/wikispeedruns/prompts.py
+++ b/wikispeedruns/prompts.py
@@ -252,14 +252,30 @@ def get_active_prompts(prompt_type: PromptType, user_id: Optional[int]=None,) ->
 
     return prompts
 
-def get_archive_prompts(prompt_type: PromptType, user_id: Optional[int]=None, offset: int=0, limit: int=20) -> Tuple[List[Prompt], int]:
+def get_archive_prompts(prompt_type: PromptType, user_id: Optional[int]=None, offset: int=0, limit: int=20, search: Optional[str]=None) -> Tuple[List[Prompt], int]:
     '''
     Get all prompts for archive, including currently active
     '''
 
     query, args = _construct_prompt_user_query(prompt_type, user_id)
     if (prompt_type == "sprint"):
-        query += f" WHERE used = 1 AND active_start <= NOW() ORDER BY active_start DESC, prompt_id DESC LIMIT %(offset)s, %(limit)s"
+        query += " WHERE used = 1 AND active_start <= NOW()"
+
+        if (search is not None and search.strip()):
+            args["search"] = f"%{search.strip().lower()}%"
+            query += """
+            ORDER BY
+                CASE
+                    WHEN LOWER(start) LIKE %(search)s OR LOWER(end) LIKE %(search)s THEN 0
+                    ELSE 1
+                END,
+                active_start DESC,
+                prompt_id DESC
+            """
+        else:
+            query += " ORDER BY active_start DESC, prompt_id DESC"
+
+        query += " LIMIT %(offset)s, %(limit)s"
         count_query = "SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW()"
     elif (prompt_type == "marathon"):
         query += f" ORDER BY prompt_id DESC LIMIT %(offset)s, %(limit)s"
@@ -364,4 +380,3 @@ def check_for_sprint_duplicates(start: str, end: str) -> Tuple[str, int]:
             return ('cmty', res_cmty['pending_prompt_id'])
 
         return ('none', -1)
-

--- a/wikispeedruns/prompts.py
+++ b/wikispeedruns/prompts.py
@@ -7,6 +7,7 @@ import pymysql
 from pymysql.cursors import DictCursor
 
 import datetime
+import re
 
 # TODO account for marathon prompts here
 
@@ -262,21 +263,16 @@ def get_archive_prompts(prompt_type: PromptType, user_id: Optional[int]=None, of
         query += " WHERE used = 1 AND active_start <= NOW()"
 
         if (search is not None and search.strip()):
-            args["search"] = f"%{search.strip().lower()}%"
-            query += """
-            ORDER BY
-                CASE
-                    WHEN LOWER(start) LIKE %(search)s OR LOWER(end) LIKE %(search)s THEN 0
-                    ELSE 1
-                END,
-                active_start DESC,
-                prompt_id DESC
-            """
+            escaped = re.sub(r'([%_\\])', r'\\\1', search.strip().lower())
+            args["search"] = f"%{escaped}%"
+            query += " AND (LOWER(start) LIKE %(search)s OR LOWER(end) LIKE %(search)s)"
+            query += " ORDER BY active_start DESC, prompt_id DESC"
+            count_query = "SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW() AND (LOWER(start) LIKE %(search)s OR LOWER(end) LIKE %(search)s)"
         else:
             query += " ORDER BY active_start DESC, prompt_id DESC"
+            count_query = "SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW()"
 
         query += " LIMIT %(offset)s, %(limit)s"
-        count_query = "SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW()"
     elif (prompt_type == "marathon"):
         query += f" ORDER BY prompt_id DESC LIMIT %(offset)s, %(limit)s"
         count_query = "SELECT COUNT(*) AS n FROM marathonprompts"
@@ -297,7 +293,7 @@ def get_archive_prompts(prompt_type: PromptType, user_id: Optional[int]=None, of
                 if (p['active']): p['end'] = None
 
         # get the total number of prompts
-        cur.execute(count_query)
+        cur.execute(count_query, args)
         n = cur.fetchone()['n']
 
         return prompts, n

--- a/wikispeedruns/prompts.py
+++ b/wikispeedruns/prompts.py
@@ -265,9 +265,10 @@ def get_archive_prompts(prompt_type: PromptType, user_id: Optional[int]=None, of
         if (search is not None and search.strip()):
             escaped = re.sub(r'([%_\\])', r'\\\1', search.strip().lower())
             args["search"] = f"%{escaped}%"
-            query += " AND (LOWER(start) LIKE %(search)s OR LOWER(end) LIKE %(search)s)"
+            archive_search_filter = "LOWER(start) LIKE %(search)s ESCAPE '\\\\' OR (active_end < NOW() AND LOWER(end) LIKE %(search)s ESCAPE '\\\\')"
+            query += f" AND ({archive_search_filter})"
             query += " ORDER BY active_start DESC, prompt_id DESC"
-            count_query = "SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW() AND (LOWER(start) LIKE %(search)s OR LOWER(end) LIKE %(search)s)"
+            count_query = f"SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW() AND ({archive_search_filter})"
         else:
             query += " ORDER BY active_start DESC, prompt_id DESC"
             count_query = "SELECT COUNT(*) AS n FROM sprint_prompts WHERE used = 1 AND active_start <= NOW()"


### PR DESCRIPTION
The main site has 1700+ prompts. This PR allows users to search through the prompts by the "Starting Article" and "Ending Article" fields.

Changes:

- search is done with a simple sql query, no indexes or anything since there are only ~thousands of queries
- relevant search results are slightly shaded in the background and the matching substring is highlighted