### PR TITLE
Clamp the limit parameter to 50

### DIFF
--- a/apis/generator_api.py
+++ b/apis/generator_api.py
@@ -6,6 +6,7 @@ generator_api = Blueprint("generator", __name__, url_prefix="/api/generator")
 
 OFFSET = 100
 LIMIT = 300000
+MAX_NUM_ARTICLES = 50
 
 # Load in file when imported
 articles = []
@@ -37,8 +38,11 @@ def get_random_prompt():
     if (count == 0):
         return "Prompt generation not setup", 500
 
-    num = int(request.args.get('num_articles', 1))
-    difficulty = int(request.args.get('difficulty', 10000))
+    try:
+        num = max(1, min(int(request.args.get('num_articles', 1)), MAX_NUM_ARTICLES))
+        difficulty = int(request.args.get('difficulty', 10000))
+    except ValueError:
+        return "Invalid num_articles or difficulty", 400
 
     if (difficulty >= LIMIT or difficulty < 10):
         return f"Invalid difficulty, should be between 10 and {LIMIT}", 400

--- a/apis/leaderboard_api.py
+++ b/apis/leaderboard_api.py
@@ -6,6 +6,17 @@ from wikispeedruns import leaderboards, lobbys, prompts
 
 leaderboard_api = Blueprint('leaderboards', __name__, url_prefix='/api')
 
+MAX_LEADERBOARD_LIMIT = 100
+
+
+def _clamp_leaderboard_limit(payload):
+    # Cap caller-supplied limit to bound the row count returned by /leaderboard.
+    # /stats receives this too but discards it — stats aggregate over the full filtered set.
+    if "limit" in payload and payload["limit"] is not None:
+        payload["limit"] = max(1, min(int(payload["limit"]), MAX_LEADERBOARD_LIMIT))
+    return payload
+
+
 LEADERBOARD_JSON = {
     field: OptionalArg(basetype)
     for field, basetype in {
@@ -34,7 +45,7 @@ def get_sprint_leaderboard(prompt_id, run_id):
     resp = leaderboards.get_leaderboard_runs(
         prompt_id=prompt_id,
         run_id=run_id,
-        **request.json
+        **_clamp_leaderboard_limit(request.json)
     )
 
     resp["prompt"] = prompts.get_prompt(prompt_id=prompt_id, prompt_type="sprint")
@@ -53,7 +64,7 @@ def get_lobby_leaderboard(lobby_id, prompt_id, run_id):
         lobby_id=lobby_id,
         prompt_id=prompt_id,
         run_id=run_id,
-        **request.json
+        **_clamp_leaderboard_limit(request.json)
     )
 
     prompts = lobbys.get_lobby_prompts(lobby_id=lobby_id, prompt_id=prompt_id)
@@ -70,7 +81,7 @@ def get_sprint_leaderboard_stats(prompt_id, run_id):
     resp = leaderboards.get_leaderboard_stats(
         prompt_id=prompt_id,
         run_id=run_id,
-        **request.json
+        **_clamp_leaderboard_limit(request.json)
     )
 
     return jsonify(resp), 200
@@ -83,7 +94,7 @@ def get_lobby_leaderboard_stats(lobby_id, prompt_id, run_id):
         lobby_id=lobby_id,
         prompt_id=prompt_id,
         run_id=run_id,
-        **request.json
+        **_clamp_leaderboard_limit(request.json)
     )
 
     return jsonify(resp), 200

--- a/apis/marathon_api.py
+++ b/apis/marathon_api.py
@@ -10,6 +10,7 @@ from wikispeedruns.marathon import genPrompts
 from wikispeedruns import prompts
 
 marathon_api = Blueprint('marathon', __name__, url_prefix='/api/marathon')
+MAX_ARCHIVE_LIMIT = 50
 
 
 @marathon_api.post('/runs/')
@@ -239,7 +240,7 @@ def get_marathon_personal_leaderboard(username):
 @marathon_api.get('/archive')
 def get_archive_prompts():
     try:
-        limit = int(request.args.get('limit', 20))
+        limit = max(1, min(int(request.args.get('limit', 20)), MAX_ARCHIVE_LIMIT))
         offset = int(request.args.get('offset', 0))
         marathons, num_prompts = prompts.get_archive_prompts("marathon",
             offset=offset,

--- a/apis/marathon_api.py
+++ b/apis/marathon_api.py
@@ -125,9 +125,9 @@ def get_all_marathon_prompts():
 
 
 @marathon_api.get('/get_prompts')
-def get_marathon_prompts():    
+def get_marathon_prompts():
     try:
-        limit = int(request.args.get('limit', 5))
+        limit = max(1, min(int(request.args.get('limit', 5)), MAX_ARCHIVE_LIMIT))
         marathons, _ = prompts.get_archive_prompts("marathon",
             limit=limit)
 

--- a/apis/runs_api.py
+++ b/apis/runs_api.py
@@ -13,6 +13,7 @@ import random
 
 # Does not have its own prefix, instead part of the lobbys and sprints apis
 run_api = Blueprint('runs', __name__, url_prefix='/api')
+MAX_SUGGESTED_NUM = 50
 
 
 @run_api.post('/sprints/<int:prompt_id>/runs')
@@ -193,8 +194,10 @@ def get_quick_run(id):
 
 @run_api.get('/quick_run/suggested')
 def get_most_recent_quick_run_prompts():
-    
-    num = int(request.args.get('num'))
+    try:
+        num = max(1, min(int(request.args.get('num', 5)), MAX_SUGGESTED_NUM))
+    except (TypeError, ValueError):
+        return "Invalid num", 400
 
     query = '''
     SELECT * FROM (

--- a/apis/sprints_api.py
+++ b/apis/sprints_api.py
@@ -11,6 +11,7 @@ from util.decorators import check_admin, check_request_json
 from wikispeedruns import prompts
 
 sprint_api = Blueprint('sprints', __name__, url_prefix='/api/sprints')
+MAX_ARCHIVE_LIMIT = 50
 
 
 ### Prompt Management Endpoints
@@ -108,7 +109,7 @@ def get_active_prompts():
 @sprint_api.get('/archive')
 def get_archive_prompts():
     try:
-        limit = int(request.args.get('limit', 20))
+        limit = max(1, min(int(request.args.get('limit', 20)), MAX_ARCHIVE_LIMIT))
         offset = int(request.args.get('offset', 0))
         sprints, num_prompts = prompts.get_archive_prompts("sprint",
             offset=offset,

--- a/app/views.py
+++ b/app/views.py
@@ -8,6 +8,7 @@ import random
 import wikispeedruns
 
 views = Blueprint("views", __name__)
+MAX_ARCHIVE_LIMIT = 50
 
 # Passes session args to function if needed
 def render_with_data(template, **kwargs):
@@ -37,7 +38,7 @@ def get_about_page():
 @views.route('/archive', methods=['GET'])
 def get_archive_page():
     try:
-        limit = int(request.args.get('limit', 20))
+        limit = max(1, min(int(request.args.get('limit', 20)), MAX_ARCHIVE_LIMIT))
         offset = int(request.args.get('offset', 0))
         return render_with_data('archive.html', limit=limit, offset=offset)
     except ValueError:
@@ -46,7 +47,7 @@ def get_archive_page():
 @views.route('/marathon_archive', methods=['GET'])
 def get_marathon_archive_page():
     try:
-        limit = int(request.args.get('limit', 10))
+        limit = max(1, min(int(request.args.get('limit', 10)), MAX_ARCHIVE_LIMIT))
         offset = int(request.args.get('offset', 0))
         return render_with_data('marathon_archive.html', limit=limit, offset=offset)
     except ValueError:

--- a/wikispeedruns/leaderboards.py
+++ b/wikispeedruns/leaderboards.py
@@ -304,6 +304,10 @@ def get_leaderboard_stats(
     run_id: Optional[int] = None,
     **kwargs
 ):
+    # Stats aggregate over the whole filtered set, not a page. Drop any caller-
+    # supplied pagination so it doesn't collide with the explicit limit=None below.
+    kwargs.pop("limit", None)
+    kwargs.pop("offset", None)
     lb_query = get_leaderboard_runs(prompt_id, lobby_id, run_id, limit=None, offset=0, query_only=True, **kwargs)
 
     query = f'''


### PR DESCRIPTION
Display at most 50 results per page on the archive page, to prevent abuse.