### PR TITLE
More lobby options

### DIFF
--- a/apis/lobbys_api.py
+++ b/apis/lobbys_api.py
@@ -115,7 +115,10 @@ def add_lobby_prompt(lobby_id):
     user_id = session.get("user_id")
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
 
-    if user_info is None or not user_info["owner"]:
+    lobby = lobbys.get_lobby(lobby_id)
+    allow_anyone = lobby and lobby.get("rules", {}).get("allow_anyone_add_prompts", False)
+
+    if user_info is None or (not user_info["owner"] and not allow_anyone):
         return "Only the owner can add prompts to this lobby", 401
 
     start = request.json["start"]

--- a/apis/lobbys_api.py
+++ b/apis/lobbys_api.py
@@ -84,10 +84,19 @@ def get_lobby(lobby_id):
     lobby_user_info = {}
     if "user_id" in session:
         lobby_user_info["name"] = session["username"]
-        lobby_user_info["owner"] = lobbys.get_lobby_user_info(lobby_id, session["user_id"]).get("owner", False)
+        info = lobbys.get_lobby_user_info(lobby_id, session["user_id"]) or {}
+        is_admin = bool(info.get("owner"))
+        is_host = bool(info.get("is_host"))
+        # Keep `owner` for backwards-compatibility with any client that still
+        # reads it; it now means "is admin" (the role formerly known as owner).
+        lobby_user_info["owner"] = is_admin
+        lobby_user_info["is_admin"] = is_admin
+        lobby_user_info["is_host"] = is_host
     else:
         lobby_user_info["name"] = session["lobbys"][str(lobby_id)]
         lobby_user_info["owner"] = False
+        lobby_user_info["is_admin"] = False
+        lobby_user_info["is_host"] = False
 
     lobby_info["user"] = lobby_user_info
 
@@ -101,14 +110,14 @@ def update_lobby(lobby_id):
     user_id = session.get("user_id")
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
 
-    if user_info is None or not user_info["owner"]:
-        return "Only the owner can add prompts to this lobby", 401
+    if user_info is None or not user_info["is_host"]:
+        return "Only a host can edit lobby settings", 401
 
     rules = request.json.get("rules")
     name = request.json.get("name")
     desc = request.json.get("desc")
 
-    lobbys.update_lobby(rules=rules, name=name, desc=desc)
+    lobbys.update_lobby(lobby_id, rules=rules, name=name, desc=desc)
 
     return "Updated lobby", 200
 
@@ -121,13 +130,13 @@ def add_lobby_prompt(lobby_id):
 
     user_id = session.get("user_id")
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id) if user_id is not None else None
-    is_owner = bool(user_info and user_info["owner"])
+    is_host = bool(user_info and user_info["is_host"])
 
     lobby = lobbys.get_lobby(lobby_id)
     allow_anyone = lobby and lobby.get("rules", {}).get("allow_anyone_add_prompts", False)
 
-    if not is_owner and not allow_anyone:
-        return "Only the owner can add prompts to this lobby", 401
+    if not is_host and not allow_anyone:
+        return "Only a host can add prompts to this lobby", 401
 
     if allow_anyone and lobbys.count_lobby_prompts(lobby_id) >= ANON_LOBBY_PROMPT_CAP:
         return f"Lobby has reached its {ANON_LOBBY_PROMPT_CAP} prompt limit", 400
@@ -171,8 +180,8 @@ def delete_lobby_prompts(lobby_id):
     user_id = session.get("user_id")
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
 
-    if user_info is None or not user_info["owner"]:
-        return "Only the owner can delete prompts from this lobby", 401
+    if user_info is None or not user_info["is_host"]:
+        return "Only a host can delete prompts from this lobby", 401
 
     prompts = request.json["prompts"]
 
@@ -219,8 +228,8 @@ def get_lobby_users(lobby_id):
     user_id = session.get("user_id")
 
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
-    if user_info is None or not user_info["owner"]:
-        return "Only the host can check the list of lobby users", 401
+    if user_info is None or not user_info["is_host"]:
+        return "Only a host can check the list of lobby users", 401
 
     return jsonify(lobbys.get_lobby_users(lobby_id)), 200
 
@@ -232,8 +241,8 @@ def get_lobby_anon_users(lobby_id):
     user_id = session.get("user_id")
 
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
-    if user_info is None or not user_info["owner"]:
-        return "Only the host can check the list of lobby users", 401
+    if user_info is None or not user_info["is_host"]:
+        return "Only a host can check the list of lobby users", 401
 
     return jsonify(lobbys.get_lobby_anon_users(lobby_id)), 200
 
@@ -243,19 +252,20 @@ def get_lobby_anon_users(lobby_id):
 @check_user
 @check_request_json({"target_user_id": int})
 def change_lobby_host(lobby_id):
+    """Promote a member to host. Admin-only."""
 
     user_id = session.get("user_id")
     target_user_id = request.json["target_user_id"]
 
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
     if user_info is None or not user_info["owner"]:
-        return "Only a host can promote another user", 401
+        return "Only the admin can promote hosts", 401
 
     if not lobbys.check_user_membership(lobby_id, target_user_id):
         return "Target user is not a member of this lobby", 400
 
     target_info = lobbys.get_lobby_user_info(lobby_id, target_user_id)
-    if target_info and target_info["owner"]:
+    if target_info and target_info["is_host"]:
         return "User is already a host!", 400
 
     lobbys.add_lobby_host(lobby_id, target_user_id)
@@ -267,24 +277,62 @@ def change_lobby_host(lobby_id):
 @check_user
 @check_request_json({"target_user_id": int})
 def remove_lobby_host(lobby_id):
+    """Demote a host to plain member. Admin-only. Cannot demote the admin."""
 
     user_id = session.get("user_id")
     target_user_id = request.json["target_user_id"]
 
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
     if user_info is None or not user_info["owner"]:
-        return "Only a host can demote another host", 401
+        return "Only the admin can demote hosts", 401
 
     if user_id == target_user_id:
-        return "Cannot demote yourself, use leave lobby instead", 400
+        return "Admins cannot self-demote; transfer admin first", 400
 
     target_info = lobbys.get_lobby_user_info(lobby_id, target_user_id)
-    if target_info is None or not target_info["owner"]:
+    if target_info is None or not target_info["host"]:
         return "Target user is not a host", 400
 
     lobbys.remove_lobby_host(lobby_id, target_user_id)
 
     return "Host removed", 200
+
+
+@lobby_api.patch("/transfer_admin/<int:lobby_id>")
+@check_user
+@check_request_json({"target_user_id": int})
+def transfer_lobby_admin(lobby_id):
+    """Transfer admin status to an existing host. Admin-only.
+
+    The previous admin is demoted to host=1 so they retain host privileges.
+    Target must already be a host — this matches the UI (Transfer Admin is
+    a per-row action on host rows) and forces the admin to make a deliberate
+    "promote then transfer" choice rather than handing admin to an arbitrary
+    member in one step.
+    """
+
+    user_id = session.get("user_id")
+    target_user_id = request.json["target_user_id"]
+
+    user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
+    if user_info is None or not user_info["owner"]:
+        return "Only the admin can transfer admin status", 401
+
+    if user_id == target_user_id:
+        return "You are already the admin", 400
+
+    target_info = lobbys.get_lobby_user_info(lobby_id, target_user_id)
+    if target_info is None:
+        return "Target user is not a member of this lobby", 400
+    if not target_info["host"]:
+        return "Target user must be a host before admin can be transferred", 400
+
+    if not lobbys.transfer_admin(lobby_id, target_user_id):
+        # Lost a TOCTOU race: target's user_lobbys row vanished between the
+        # check above and the transfer SQL. Original admin retained.
+        return "Target user is no longer a member of this lobby", 409
+
+    return "Admin transferred", 200
 
 
 @lobby_api.delete("/<int:lobby_id>")
@@ -294,7 +342,7 @@ def hide_lobby(lobby_id):
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
 
     if user_info is None or not user_info["owner"]:
-        return "Only the owner can delete the lobby", 401
+        return "Only the admin can delete the lobby", 401
 
     lobbys.hide_lobby(lobby_id)
     return "Lobby Deleted!", 200
@@ -303,14 +351,15 @@ def hide_lobby(lobby_id):
 def leave_lobby(lobby_id):
     if not lobbys.check_membership(lobby_id, session):
         return "You do not have access to this lobby", 401
-    
+
     user_id = session.get("user_id")
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
 
-    # Hosts can only leave if there is at least one other host
+    # Admin must hand off before leaving — otherwise the lobby would be left
+    # without an admin (and account-deletion handoff only fires when the
+    # account is deleted, not on leave).
     if user_info and user_info["owner"]:
-        if lobbys.count_lobby_hosts(lobby_id) <= 1:
-            return "The last host cannot leave the lobby", 400
+        return "Admins must transfer admin status before leaving the lobby", 400
 
     lobbys.leave_lobby(user_id, lobby_id)
     return "Left Lobby!", 200

--- a/apis/lobbys_api.py
+++ b/apis/lobbys_api.py
@@ -10,6 +10,11 @@ from wikispeedruns import lobbys
 
 lobby_api = Blueprint('lobbys', __name__, url_prefix='/api/lobbys')
 
+# Cap on total prompts in a lobby with allow_anyone_add_prompts=True, to
+# limit abuse from passcode-holding anon submitters. Owner can delete to
+# free space.
+ANON_LOBBY_PROMPT_CAP = 100
+
 
 # TODO allow anonymous users?
 @lobby_api.post("")
@@ -109,17 +114,23 @@ def update_lobby(lobby_id):
 
 # Prompts
 @lobby_api.post("/<int:lobby_id>/prompts")
-@check_user
 @check_request_json({"start": str, "end": str, "language": str})
 def add_lobby_prompt(lobby_id):
+    if not lobbys.check_membership(lobby_id, session):
+        return "You are not a member of this lobby", 401
+
     user_id = session.get("user_id")
-    user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
+    user_info = lobbys.get_lobby_user_info(lobby_id, user_id) if user_id is not None else None
+    is_owner = bool(user_info and user_info["owner"])
 
     lobby = lobbys.get_lobby(lobby_id)
     allow_anyone = lobby and lobby.get("rules", {}).get("allow_anyone_add_prompts", False)
 
-    if user_info is None or (not user_info["owner"] and not allow_anyone):
+    if not is_owner and not allow_anyone:
         return "Only the owner can add prompts to this lobby", 401
+
+    if allow_anyone and lobbys.count_lobby_prompts(lobby_id) >= ANON_LOBBY_PROMPT_CAP:
+        return f"Lobby has reached its {ANON_LOBBY_PROMPT_CAP} prompt limit", 400
 
     start = request.json["start"]
     end = request.json["end"]

--- a/apis/lobbys_api.py
+++ b/apis/lobbys_api.py
@@ -238,16 +238,42 @@ def change_lobby_host(lobby_id):
 
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
     if user_info is None or not user_info["owner"]:
-        return "Only the host can change host to another user", 401
+        return "Only a host can promote another user", 401
 
-    if user_id == target_user_id:
-        return "User is already lobby host!", 400
     if not lobbys.check_user_membership(lobby_id, target_user_id):
         return "Target user is not a member of this lobby", 400
 
-    lobbys.change_lobby_host(lobby_id, target_user_id)
+    target_info = lobbys.get_lobby_user_info(lobby_id, target_user_id)
+    if target_info and target_info["owner"]:
+        return "User is already a host!", 400
 
-    return "Lobby host changed successfully", 200
+    lobbys.add_lobby_host(lobby_id, target_user_id)
+
+    return "User promoted to host", 200
+
+
+@lobby_api.patch("/remove_host/<int:lobby_id>")
+@check_user
+@check_request_json({"target_user_id": int})
+def remove_lobby_host(lobby_id):
+
+    user_id = session.get("user_id")
+    target_user_id = request.json["target_user_id"]
+
+    user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
+    if user_info is None or not user_info["owner"]:
+        return "Only a host can demote another host", 401
+
+    if user_id == target_user_id:
+        return "Cannot demote yourself, use leave lobby instead", 400
+
+    target_info = lobbys.get_lobby_user_info(lobby_id, target_user_id)
+    if target_info is None or not target_info["owner"]:
+        return "Target user is not a host", 400
+
+    lobbys.remove_lobby_host(lobby_id, target_user_id)
+
+    return "Host removed", 200
 
 
 @lobby_api.delete("/<int:lobby_id>")
@@ -270,9 +296,10 @@ def leave_lobby(lobby_id):
     user_id = session.get("user_id")
     user_info = lobbys.get_lobby_user_info(lobby_id, user_id)
 
-    # Check for lobby ownership - owners can't leave their own lobbies
+    # Hosts can only leave if there is at least one other host
     if user_info and user_info["owner"]:
-        return "The owner cannot leave the lobby", 400
-    
+        if lobbys.count_lobby_hosts(lobby_id) <= 1:
+            return "The last host cannot leave the lobby", 400
+
     lobbys.leave_lobby(user_id, lobby_id)
     return "Left Lobby!", 200

--- a/apis/users_api.py
+++ b/apis/users_api.py
@@ -502,9 +502,25 @@ def delete_account():
     delete from users where user_id = %(user_id)s
     """
 
-    get_hosted_lobbies_query = """
+    # Find lobbies this user admins. Pre-2.7 the query was `owner=1` which,
+    # after the multi-host commit, would cascade-delete co-hosted lobbies the
+    # user did not create. Now `owner=1` strictly means admin.
+    get_admin_lobbies_query = """
     select lobby_id from user_lobbys
     WHERE user_id=%(user_id)s AND owner = 1
+    """
+
+    # For each admin'd lobby, find another host (host=1) to hand off to.
+    # MIN(user_id) gives a deterministic pick.
+    find_handoff_query = """
+    SELECT MIN(user_id) AS new_admin
+    FROM user_lobbys
+    WHERE lobby_id=%s AND host=1 AND user_id != %s
+    """
+
+    promote_handoff_query = """
+    UPDATE user_lobbys SET owner=1, host=0
+    WHERE lobby_id=%s AND user_id=%s
     """
 
     delete_lobbies_query1 = """
@@ -530,16 +546,26 @@ def delete_account():
     db = get_db()
     with db.cursor(cursor=DictCursor) as cursor:
 
-        count = cursor.execute(get_hosted_lobbies_query, args)
+        cursor.execute(get_admin_lobbies_query, args)
+        admin_lobbies = [x["lobby_id"] for x in cursor.fetchall()]
 
-        lobbies = cursor.fetchall()
-        lobby_ids = [str(x['lobby_id']) for x in lobbies]
+        # For each admin'd lobby, try to hand off to another host before
+        # falling back to delete.
+        lobbies_to_delete = []
+        for lobby_id in admin_lobbies:
+            cursor.execute(find_handoff_query, (lobby_id, id))
+            row = cursor.fetchone()
+            new_admin = row["new_admin"] if row else None
+            if new_admin is not None:
+                cursor.execute(promote_handoff_query, (lobby_id, new_admin))
+            else:
+                lobbies_to_delete.append(str(lobby_id))
 
-        if (count > 0):
-            cursor.executemany(delete_lobbies_query1, lobby_ids)
-            cursor.executemany(delete_lobbies_query2, lobby_ids)
-            cursor.executemany(delete_lobbies_query3, lobby_ids)
-            cursor.executemany(delete_lobbies_query4, lobby_ids)
+        if lobbies_to_delete:
+            cursor.executemany(delete_lobbies_query1, lobbies_to_delete)
+            cursor.executemany(delete_lobbies_query2, lobbies_to_delete)
+            cursor.executemany(delete_lobbies_query3, lobbies_to_delete)
+            cursor.executemany(delete_lobbies_query4, lobbies_to_delete)
 
         cursor.execute(user_query1, args)
         cursor.execute(user_query2, args)

--- a/apis/users_api.py
+++ b/apis/users_api.py
@@ -550,15 +550,20 @@ def delete_account():
         admin_lobbies = [x["lobby_id"] for x in cursor.fetchall()]
 
         # For each admin'd lobby, try to hand off to another host before
-        # falling back to delete.
+        # falling back to delete. If the promote UPDATE affects 0 rows
+        # (chosen host's row vanished via a racing leave/delete between the
+        # find and the promote), fall through to deletion rather than
+        # leaving the lobby admin-less.
         lobbies_to_delete = []
         for lobby_id in admin_lobbies:
             cursor.execute(find_handoff_query, (lobby_id, id))
             row = cursor.fetchone()
             new_admin = row["new_admin"] if row else None
+            handed_off = False
             if new_admin is not None:
                 cursor.execute(promote_handoff_query, (lobby_id, new_admin))
-            else:
+                handed_off = cursor.rowcount > 0
+            if not handed_off:
                 lobbies_to_delete.append(str(lobby_id))
 
         if lobbies_to_delete:

--- a/app/db.py
+++ b/app/db.py
@@ -17,7 +17,7 @@ def get_conn_info():
 
 # Keep up to date with scripts/schema.sql
 def get_db_version():
-    return '2.6'
+    return '2.7'
 
 def get_db():
     if _instance_db:

--- a/app/views.py
+++ b/app/views.py
@@ -120,10 +120,11 @@ def get_quick_run_page():
         prompt_start = request.args.get('prompt_start', None)
         prompt_end = request.args.get('prompt_end', None)
         scroll = request.args.get('scroll', None)
+        allow_namespace_links = request.args.get('allow_namespace_links', None)
         lang = request.args.get('lang', 'en')
         if prompt_start is None or prompt_end is None or not lang.strip():
             return "Invalid request", 400
-        return render_with_data('play.html', prompt_start=prompt_start, prompt_end=prompt_end, scroll=scroll, lang=lang)
+        return render_with_data('play.html', prompt_start=prompt_start, prompt_end=prompt_end, scroll=scroll, lang=lang, allow_namespace_links=allow_namespace_links)
     except ValueError:
         return "Page Not Found", 404
 

--- a/frontend/static/js/modules/customPlay.js
+++ b/frontend/static/js/modules/customPlay.js
@@ -18,6 +18,7 @@ var CustomPlay = {
             articleCheckMessage: "",
 
             scroll: null,
+            allowNamespaceLinks: false,
 
             language: "en",
             languages: [],
@@ -49,7 +50,7 @@ var CustomPlay = {
         },
 
         play(start, end, lang) {
-            let quickPlayUrl = `/play/quick_play?prompt_start=${encodeURIComponent(start)}&prompt_end=${encodeURIComponent(end)}&lang=${lang}${this.scroll ? '&scroll=1' : ''}`;
+            let quickPlayUrl = `/play/quick_play?prompt_start=${encodeURIComponent(start)}&prompt_end=${encodeURIComponent(end)}&lang=${lang}${this.scroll ? '&scroll=1' : ''}${this.allowNamespaceLinks ? '&allow_namespace_links=1' : ''}`;
             window.location.assign(quickPlayUrl);
         },
 
@@ -124,6 +125,16 @@ var CustomPlay = {
                 <label class="form-check-label">
                     <input class="form-check-input" type="checkbox" v-model="scroll">
                     Enable auto-scrolling
+                </label>
+            </div>
+
+            <div class="form-check">
+                <label class="form-check-label">
+                    <input class="form-check-input" type="checkbox" v-model="allowNamespaceLinks">
+                    Allow namespace links
+                    <span class="text-muted fw-light">(e.g. Wikipedia:, Category:, Portal:)</span>
+                    <br v-if="allowNamespaceLinks">
+                    <span v-if="allowNamespaceLinks" class="text-danger fw-light">Warning: Navigating into namespaces may leave you stuck with no way back to regular articles</span>
                 </label>
             </div>
 

--- a/frontend/static/js/modules/game/articleRenderer.js
+++ b/frontend/static/js/modules/game/articleRenderer.js
@@ -11,7 +11,7 @@ export class ArticleRenderer {
      *
      * revisionDate: date for article revisions are tied to.
      */
-    constructor(frame, pageCallback, mouseEnter, mouseLeave, loadCallback, language, revisionDate) {
+    constructor(frame, pageCallback, mouseEnter, mouseLeave, loadCallback, language, revisionDate, allowNamespaceLinks = false) {
         this.frame = frame;
         this.frame.classList.add("wiki-insert");
 
@@ -23,6 +23,7 @@ export class ArticleRenderer {
 
         this.revisionDate = revisionDate;
         this.isLoadingPage = false;
+        this.allowNamespaceLinks = allowNamespaceLinks;
     }
 
     async loadPage(page) {
@@ -72,7 +73,7 @@ export class ArticleRenderer {
                 disableLazyLoading(this.frame);
             }
             hideElements(this.frame);
-            stripNonArticleLinks(this.frame);
+            stripNonArticleLinks(this.frame, this.allowNamespaceLinks);
 
         } catch (error) {
             console.error("Error rendering in page somewhere:", error)
@@ -90,7 +91,7 @@ export class ArticleRenderer {
             }
             el.removeAttribute("title");
 
-            if (this.mouseEnter && this.mouseLeave && !isMobile && isNormalWikipediaArticleLink(href)) {
+            if (this.mouseEnter && this.mouseLeave && !isMobile && isNormalWikipediaArticleLink(href, this.allowNamespaceLinks)) {
                 el.onmouseenter = this.mouseEnter;
                 el.onmouseleave = this.mouseLeave;
             }
@@ -113,7 +114,7 @@ export class ArticleRenderer {
             document.getElementById(a)?.scrollIntoView();
 
         } else {
-            if (!isNormalWikipediaArticleLink(href) || this.isLoadingPage) {
+            if (!isNormalWikipediaArticleLink(href, this.allowNamespaceLinks) || this.isLoadingPage) {
                 return;
             }
 
@@ -202,11 +203,11 @@ function hideElements(frame) {
 
 }
 
-function stripNonArticleLinks(frame) {
+function stripNonArticleLinks(frame, allowNamespaceLinks = false) {
 
     frame.querySelectorAll("a").forEach((linkEl) => {
         const href = linkEl.getAttribute("href");
-        if (href && href.substring(0, 1) !== "#" && !isNormalWikipediaArticleLink(href)) {
+        if (href && href.substring(0, 1) !== "#" && !isNormalWikipediaArticleLink(href, allowNamespaceLinks)) {
             let newEl = document.createElement("span");
             newEl.innerHTML = linkEl.innerHTML
             linkEl.parentNode.replaceChild(newEl, linkEl)
@@ -220,10 +221,16 @@ function renderLoadFailure(frame) {
     }
 }
 
-function isNormalWikipediaArticleLink(href) {
-    return !!href &&
-        href.startsWith("/wiki/") &&
-        !href.startsWith("/wiki/File:") &&
+function isNormalWikipediaArticleLink(href, allowNamespaceLinks = false) {
+    if (!href || !href.startsWith("/wiki/") || href.endsWith("&redlink=1")) {
+        return false;
+    }
+
+    if (allowNamespaceLinks) {
+        return true;
+    }
+
+    return !href.startsWith("/wiki/File:") &&
         !href.startsWith("/wiki/Wikipedia:") &&
         !href.startsWith("/wiki/Category:") &&
         !href.startsWith("/wiki/Special:") &&
@@ -233,6 +240,5 @@ function isNormalWikipediaArticleLink(href) {
         !href.startsWith("/wiki/Module:") &&
         !href.startsWith("/wiki/MediaWiki:") &&
         !href.startsWith("/wiki/Template_talk:") &&
-        !href.startsWith("/wiki/Portal_talk:") &&
-        !href.endsWith("&redlink=1");
+        !href.startsWith("/wiki/Portal_talk:");
 }

--- a/frontend/static/js/pages/lobbys/create.js
+++ b/frontend/static/js/pages/lobbys/create.js
@@ -16,6 +16,7 @@ var app = new Vue({
         penaltyMode: false,
         findHotkeyMode: false,
         allowNamespaceLinks: false,
+        allowAnyoneAddPrompts: false,
     },
 
     methods: {
@@ -33,6 +34,7 @@ var app = new Vue({
             requestBody.rules["live_mode"] = this.liveMode;
             requestBody.rules["find_hotkey_mode"] = this.findHotkeyMode;
             requestBody.rules["allow_namespace_links"] = this.allowNamespaceLinks;
+            requestBody.rules["allow_anyone_add_prompts"] = this.allowAnyoneAddPrompts;
 
             // Only add these fields if not empty
             if (this.name) requestBody["name"] = this.name;

--- a/frontend/static/js/pages/lobbys/create.js
+++ b/frontend/static/js/pages/lobbys/create.js
@@ -15,6 +15,7 @@ var app = new Vue({
         requireAccount: false,
         penaltyMode: false,
         findHotkeyMode: false,
+        allowNamespaceLinks: false,
     },
 
     methods: {
@@ -31,6 +32,7 @@ var app = new Vue({
             requestBody.rules["is_penalty_mode"] = this.penaltyMode;
             requestBody.rules["live_mode"] = this.liveMode;
             requestBody.rules["find_hotkey_mode"] = this.findHotkeyMode;
+            requestBody.rules["allow_namespace_links"] = this.allowNamespaceLinks;
 
             // Only add these fields if not empty
             if (this.name) requestBody["name"] = this.name;

--- a/frontend/static/js/pages/lobbys/lobby.js
+++ b/frontend/static/js/pages/lobbys/lobby.js
@@ -9,6 +9,7 @@ import { UserDisplay } from "../../modules/userDisplay.js"
 import { LiveLobbyPromptsHelper } from "../../modules/live/livePrompts.js";
 
 const LOBBY_ID = serverData["lobby_id"];
+const USER_ID = serverData["user_id"] || null;
 const successMessage = "Added prompt to lobby!";
 
 var app = new Vue({
@@ -42,6 +43,7 @@ var app = new Vue({
         editPrompts: false,
         selectedPrompts: [],
 
+        currentUserId: USER_ID,
         users: null,
         anon_users: null,
 
@@ -215,7 +217,7 @@ var app = new Vue({
         },
 
         async makeHost(user_id, username) {
-            if (!confirm(`Are you sure you want to make ${username} the lobby host?`)) {
+            if (!confirm(`Make ${username} a co-host?`)) {
                 return;
             }
 
@@ -224,8 +226,36 @@ var app = new Vue({
                     "target_user_id": user_id,
                 });
 
-                alert(`${username} is now host!`);
-                window.location.reload();
+                if (resp.status !== 200) {
+                    alert(await resp.text());
+                    return;
+                }
+
+                alert(`${username} is now a co-host!`);
+                this.getLobbyUsers();
+            } catch (e) {
+                console.log(e)
+                alert(e);
+            }
+        },
+
+        async removeHost(user_id, username) {
+            if (!confirm(`Remove ${username} as co-host?`)) {
+                return;
+            }
+
+            try {
+                const resp = await fetchJson(`/api/lobbys/remove_host/${LOBBY_ID}`, "PATCH", {
+                    "target_user_id": user_id,
+                });
+
+                if (resp.status !== 200) {
+                    alert(await resp.text());
+                    return;
+                }
+
+                alert(`${username} is no longer a co-host.`);
+                this.getLobbyUsers();
             } catch (e) {
                 console.log(e)
                 alert(e);

--- a/frontend/static/js/pages/lobbys/lobby.js
+++ b/frontend/static/js/pages/lobbys/lobby.js
@@ -49,6 +49,13 @@ var app = new Vue({
         messageTimer: null
     },
 
+    computed: {
+        canAddPrompts() {
+            return this.lobbyInfo.user.owner ||
+                !!this.lobbyInfo?.rules?.allow_anyone_add_prompts;
+        }
+    },
+
     mounted: async function() {
         this.link = window.location.href;
         await Promise.all([this.getLobbyInfo(), this.getPrompts(), this.getLanguages()]);

--- a/frontend/static/js/pages/lobbys/lobby.js
+++ b/frontend/static/js/pages/lobbys/lobby.js
@@ -53,7 +53,7 @@ var app = new Vue({
 
     computed: {
         canAddPrompts() {
-            return this.lobbyInfo.user.owner ||
+            return !!this.lobbyInfo.user.is_host ||
                 !!this.lobbyInfo?.rules?.allow_anyone_add_prompts;
         }
     },
@@ -113,9 +113,15 @@ var app = new Vue({
             const resp = await fetchJson(`/api/lobbys/${LOBBY_ID}`);
             this.lobbyInfo = await resp.json();
 
-            if (this.lobbyInfo.user.owner) {
+            if (this.lobbyInfo.user.is_host) {
                 await this.getLobbyUsers();
             }
+        },
+
+        userRoleLabel(user) {
+            if (user.owner) return "Admin";
+            if (user.host) return "Host";
+            return "Member";
         },
 
         async getPrompts() {
@@ -256,6 +262,29 @@ var app = new Vue({
 
                 alert(`${username} is no longer a co-host.`);
                 this.getLobbyUsers();
+            } catch (e) {
+                console.log(e)
+                alert(e);
+            }
+        },
+
+        async transferAdmin(user_id, username) {
+            if (!confirm(`Transfer admin status to ${username}? You will become a host.`)) {
+                return;
+            }
+
+            try {
+                const resp = await fetchJson(`/api/lobbys/transfer_admin/${LOBBY_ID}`, "PATCH", {
+                    "target_user_id": user_id,
+                });
+
+                if (resp.status !== 200) {
+                    alert(await resp.text());
+                    return;
+                }
+
+                alert(`${username} is now the admin.`);
+                window.location.reload();
             } catch (e) {
                 console.log(e)
                 alert(e);

--- a/frontend/static/js/pages/marathon.js
+++ b/frontend/static/js/pages/marathon.js
@@ -307,7 +307,7 @@ window.onbeforeunload = function() {
 // Disable find hotkeys, players will be given a warning
 window.addEventListener("keydown", function(e) {
     //disable find
-    if (["F3", "/", "'"].includes(e.key) || ((e.ctrlKey || e.metaKey) && (e.key == "f" || e.key == "g"))) {
+    if (["f3", "/", "'"].includes(e.key.toLowerCase()) || ((e.ctrlKey || e.metaKey) && (e.key.toLowerCase() == "f" || e.key.toLowerCase() == "g"))) {
         e.preventDefault();
         this.alert("WARNING: Attempt to Find in page. This will be recorded.");
     }

--- a/frontend/static/js/pages/marathon.js
+++ b/frontend/static/js/pages/marathon.js
@@ -307,7 +307,7 @@ window.onbeforeunload = function() {
 // Disable find hotkeys, players will be given a warning
 window.addEventListener("keydown", function(e) {
     //disable find
-    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && (e.keyCode == 70 || e.keyCode == 71))) {
+    if (["F3", "/", "'"].includes(e.key) || ((e.ctrlKey || e.metaKey) && (e.key == "f" || e.key == "g"))) {
         e.preventDefault();
         this.alert("WARNING: Attempt to Find in page. This will be recorded.");
     }

--- a/frontend/static/js/pages/play.js
+++ b/frontend/static/js/pages/play.js
@@ -170,6 +170,8 @@ let app = new Vue({
             this.isFindHotkeyMode = !!lobby?.["rules"]?.["find_hotkey_mode"];
             this.allowNamespaceLinks = !!lobby?.["rules"]?.["allow_namespace_links"];
             this.isHost = lobby?.["user"]?.["owner"];
+        } else {
+            this.allowNamespaceLinks = !!serverData["allow_namespace_links"];
         }
 
         this.startArticle = prompt["start"];

--- a/frontend/static/js/pages/play.js
+++ b/frontend/static/js/pages/play.js
@@ -422,7 +422,7 @@ let app = new Vue({
         keydownHandler: function(e) {
             if (this.isFindHotkeyMode) return;
             
-            if (["F3", "/", "'"].includes(e.key) || ((e.ctrlKey || e.metaKey) && (e.key == "f" || e.key == "g"))) {
+            if (["f3", "/", "'"].includes(e.key.toLowerCase()) || ((e.ctrlKey || e.metaKey) && (e.key.toLowerCase() == "f" || e.key.toLowerCase() == "g"))) {
                 e.preventDefault();
                 alert("WARNING: Attempt to Find in page. This will be recorded.");
             }

--- a/frontend/static/js/pages/play.js
+++ b/frontend/static/js/pages/play.js
@@ -169,7 +169,7 @@ let app = new Vue({
             this.live = !!lobby?.["rules"]?.["live_mode"];
             this.isFindHotkeyMode = !!lobby?.["rules"]?.["find_hotkey_mode"];
             this.allowNamespaceLinks = !!lobby?.["rules"]?.["allow_namespace_links"];
-            this.isHost = lobby?.["user"]?.["owner"];
+            this.isHost = !!lobby?.["user"]?.["is_host"];
         } else {
             this.allowNamespaceLinks = !!serverData["allow_namespace_links"];
         }

--- a/frontend/static/js/pages/play.js
+++ b/frontend/static/js/pages/play.js
@@ -137,6 +137,7 @@ let app = new Vue({
 
         isPenaltyMode: false,
         isFindHotkeyMode: false,
+        allowNamespaceLinks: false,
         penaltyTime: 0,         // Additional penalty time for penalty game mode
 
         // State for live games. We need to access the username/lobby name 
@@ -167,6 +168,7 @@ let app = new Vue({
             this.isPenaltyMode = !!lobby["rules"]["is_penalty_mode"];
             this.live = !!lobby?.["rules"]?.["live_mode"];
             this.isFindHotkeyMode = !!lobby?.["rules"]?.["find_hotkey_mode"];
+            this.allowNamespaceLinks = !!lobby?.["rules"]?.["allow_namespace_links"];
             this.isHost = lobby?.["user"]?.["owner"];
         }
 
@@ -202,7 +204,8 @@ let app = new Vue({
             !this.isScroll && this.hidePreview,
             this.loadCallback,
             this.language,
-            this.revisionDate);
+            this.revisionDate,
+            this.allowNamespaceLinks);
         await this.renderer.loadPage(this.startArticle);
 
 
@@ -417,7 +420,7 @@ let app = new Vue({
         keydownHandler: function(e) {
             if (this.isFindHotkeyMode) return;
             
-            if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && (e.keyCode == 70 || e.keyCode == 71))) {
+            if (["F3", "/", "'"].includes(e.key) || ((e.ctrlKey || e.metaKey) && (e.key == "f" || e.key == "g"))) {
                 e.preventDefault();
                 alert("WARNING: Attempt to Find in page. This will be recorded.");
             }

--- a/frontend/static/js/pages/tutorial.js
+++ b/frontend/static/js/pages/tutorial.js
@@ -432,7 +432,7 @@ window.addEventListener("beforeunload", beforeUnloadListener);
 // Disable find hotkeys, players will be given a warning
 window.addEventListener("keydown", function(e) {
     //disable find
-    if ([114, 191, 222].includes(e.keyCode) || ((e.ctrlKey || e.metaKey) && (e.keyCode == 70 || e.keyCode == 71))) {
+    if (["F3", "/", "'"].includes(e.key) || ((e.ctrlKey || e.metaKey) && (e.key == "f" || e.key == "g"))) {
         e.preventDefault();
         this.alert("WARNING: Attempt to Find in page. This will be recorded.");
     }

--- a/frontend/static/js/pages/tutorial.js
+++ b/frontend/static/js/pages/tutorial.js
@@ -432,7 +432,7 @@ window.addEventListener("beforeunload", beforeUnloadListener);
 // Disable find hotkeys, players will be given a warning
 window.addEventListener("keydown", function(e) {
     //disable find
-    if (["F3", "/", "'"].includes(e.key) || ((e.ctrlKey || e.metaKey) && (e.key == "f" || e.key == "g"))) {
+    if (["f3", "/", "'"].includes(e.key.toLowerCase()) || ((e.ctrlKey || e.metaKey) && (e.key.toLowerCase() == "f" || e.key.toLowerCase() == "g"))) {
         e.preventDefault();
         this.alert("WARNING: Attempt to Find in page. This will be recorded.");
     }

--- a/frontend/templates/lobbys/create.html
+++ b/frontend/templates/lobbys/create.html
@@ -72,6 +72,10 @@
                     <span class="text-muted fw-light">
                         Let any lobby member create prompts, not just the owner
                     </span>
+                    <br v-if="allowAnyoneAddPrompts">
+                    <span v-if="allowAnyoneAddPrompts" class="text-muted fw-light">
+                        Note: lobbies with this option are capped at 100 prompts total. Delete prompts to free up space, or open a new lobby for more prompts.
+                    </span>
                 </label>
 	        </div>
 

--- a/frontend/templates/lobbys/create.html
+++ b/frontend/templates/lobbys/create.html
@@ -82,8 +82,8 @@
                     <span class="text-muted fw-light">
                         Enable all namespace links (e.g. Wikipedia:, Category:, Portal:)
                     </span>
-                    <br>
-                    <span class="text-danger fw-light">
+                    <br v-if="allowNamespaceLinks">
+                    <span v-if="allowNamespaceLinks" class="text-danger fw-light">
                         Warning: Navigating into namespaces may leave you stuck with no way back to regular articles
                     </span>
                 </label>

--- a/frontend/templates/lobbys/create.html
+++ b/frontend/templates/lobbys/create.html
@@ -66,6 +66,16 @@
 	        </div>
 
             <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="anyone-add-prompts-checkbox" v-model="allowAnyoneAddPrompts">
+                <label class="form-check-label" for="anyone-add-prompts-checkbox">
+                    <b>Allow anyone to add prompts</b>
+                    <span class="text-muted fw-light">
+                        Let any lobby member create prompts, not just the owner
+                    </span>
+                </label>
+	        </div>
+
+            <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="namespace-links-checkbox" v-model="allowNamespaceLinks">
                 <label class="form-check-label" for="namespace-links-checkbox">
                     <b>Allow namespace links</b>

--- a/frontend/templates/lobbys/create.html
+++ b/frontend/templates/lobbys/create.html
@@ -65,6 +65,20 @@
                 </label>
 	        </div>
 
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="namespace-links-checkbox" v-model="allowNamespaceLinks">
+                <label class="form-check-label" for="namespace-links-checkbox">
+                    <b>Allow namespace links</b>
+                    <span class="text-muted fw-light">
+                        Enable all namespace links (e.g. Wikipedia:, Category:, Portal:)
+                    </span>
+                    <br>
+                    <span class="text-danger fw-light">
+                        Warning: Navigating into namespaces may leave you stuck with no way back to regular articles
+                    </span>
+                </label>
+	        </div>
+
             <!--
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="req-acc-checkbox" v-model="requireAccount">

--- a/frontend/templates/lobbys/lobby.html
+++ b/frontend/templates/lobbys/lobby.html
@@ -90,7 +90,7 @@
                         <tbody>
                             <tr v-for="user in users" v-cloak>
                                 <td><user :username="user.username" /></td>
-                                <td>Registered User</td>
+                                <td>[[user.owner ? 'Host' : 'Member']]</td>
                                 <td>
                                     <div class="dropdown">
                                         <button class="btn btn-secondary dropdown-toggle"
@@ -103,8 +103,9 @@
                                         </button>
                                         <div class="dropdown-menu"
                                             v-bind:id="String(user.user_id)+'dropdown'">
-                                            <button v-if="!user.owner" class="btn btn-sm" @click="makeHost(user.user_id, user.username)">Transfer Ownership</button>
-                                            <button class="btn btn-sm disabled" v-else>Currently host</button>
+                                            <button v-if="!user.owner" class="btn btn-sm" @click="makeHost(user.user_id, user.username)">Make Co-host</button>
+                                            <button v-else-if="user.owner && user.user_id !== currentUserId" class="btn btn-sm" @click="removeHost(user.user_id, user.username)">Remove Co-host</button>
+                                            <button class="btn btn-sm disabled" v-else>You (host)</button>
                                         </div>
                                     </div>
                                 </td>

--- a/frontend/templates/lobbys/lobby.html
+++ b/frontend/templates/lobbys/lobby.html
@@ -122,6 +122,10 @@
 
         <hr>
 
+    </template>
+
+    <template v-if="canAddPrompts">
+
         <h3>Add a Prompt:</h3>
 
         <form id="newPrompt" v-on:submit.prevent="addPrompt">

--- a/frontend/templates/lobbys/lobby.html
+++ b/frontend/templates/lobbys/lobby.html
@@ -71,7 +71,7 @@
     </div>
 
 
-    <template v-if="lobbyInfo.user.owner">
+    <template v-if="lobbyInfo.user.is_host">
 
         <hr>
 
@@ -90,9 +90,9 @@
                         <tbody>
                             <tr v-for="user in users" v-cloak>
                                 <td><user :username="user.username" /></td>
-                                <td>[[user.owner ? 'Host' : 'Member']]</td>
+                                <td>[[userRoleLabel(user)]]</td>
                                 <td>
-                                    <div class="dropdown">
+                                    <div class="dropdown" v-if="lobbyInfo.user.is_admin">
                                         <button class="btn btn-secondary dropdown-toggle"
                                                 type="button"
                                                 data-toggle="dropdown"
@@ -103,9 +103,14 @@
                                         </button>
                                         <div class="dropdown-menu"
                                             v-bind:id="String(user.user_id)+'dropdown'">
-                                            <button v-if="!user.owner" class="btn btn-sm" @click="makeHost(user.user_id, user.username)">Make Co-host</button>
-                                            <button v-else-if="user.owner && user.user_id !== currentUserId" class="btn btn-sm" @click="removeHost(user.user_id, user.username)">Remove Co-host</button>
-                                            <button class="btn btn-sm disabled" v-else>You (host)</button>
+                                            <button v-if="user.user_id === currentUserId" class="btn btn-sm disabled">You (admin)</button>
+                                            <template v-else>
+                                                <button v-if="!user.owner && !user.host" class="btn btn-sm" @click="makeHost(user.user_id, user.username)">Make Co-host</button>
+                                                <template v-if="user.host">
+                                                    <button class="btn btn-sm" @click="removeHost(user.user_id, user.username)">Remove Co-host</button>
+                                                    <button class="btn btn-sm" @click="transferAdmin(user.user_id, user.username)">Transfer Admin</button>
+                                                </template>
+                                            </template>
                                         </div>
                                     </div>
                                 </td>
@@ -177,7 +182,7 @@
 
     <div class="prompt-header">
         <h3> Prompts </h3>
-        <template v-if="lobbyInfo.user.owner">
+        <template v-if="lobbyInfo.user.is_host">
             <a style="cursor:pointer" v-on:click="editPrompts = !editPrompts">(Edit)</a>
         </template>
     </div>
@@ -229,7 +234,7 @@
         </div>
     </div>
 
-    <template v-if="lobbyInfo.user.owner">
+    <template v-if="lobbyInfo.user.is_admin">
         <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteLobbyModal">
             Delete Lobby
         </button>

--- a/scripts/migrate_2_6_to_2_7.sql
+++ b/scripts/migrate_2_6_to_2_7.sql
@@ -1,0 +1,32 @@
+-- Migration 2.6 -> 2.7
+--
+-- Introduces the admin/host role split in `user_lobbys`:
+--   owner=1 -> admin (lobby creator; at most one per lobby)
+--   host=1  -> co-host (admin-promoted host)
+--
+-- The multi-host feature in commit ca34766 (2026-05-08) repurposed owner=1
+-- to mean "any host", which broke account-deletion semantics: a co-host
+-- deleting their account would cascade-delete the original creator's
+-- lobbies. This migration restores the invariant that each lobby has at
+-- most one owner=1 row, and demotes extra rows to host=1.
+
+ALTER TABLE `user_lobbys` ADD COLUMN `host` BOOLEAN DEFAULT 0;
+
+-- Backfill: for lobbies that picked up multiple owner=1 rows during the
+-- multi-host window, keep the lowest user_id as admin and demote the rest
+-- to host=1. user_lobbys has no timestamp, so MIN(user_id) is the best
+-- available proxy for "earliest joined" (the creator is inserted first by
+-- lobbys.create_lobby). For lobbies with a single owner=1, this is a no-op.
+UPDATE `user_lobbys` ul
+JOIN (
+    SELECT lobby_id, MIN(user_id) AS keeper
+    FROM `user_lobbys`
+    WHERE owner = 1
+    GROUP BY lobby_id
+    HAVING COUNT(*) > 1
+) keepers
+    ON ul.lobby_id = keepers.lobby_id
+   AND ul.user_id != keepers.keeper
+SET ul.owner = 0,
+    ul.host  = 1
+WHERE ul.owner = 1;

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -116,6 +116,7 @@ CREATE TABLE IF NOT EXISTS `lobbys` (
         restrict_leaderboard_access: (false)
         require_account: (false)
         allow_namespace_links: (false)
+        allow_anyone_add_prompts: (false)
     }
     */
 

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -115,6 +115,7 @@ CREATE TABLE IF NOT EXISTS `lobbys` (
         hide_prompt_end: (false)
         restrict_leaderboard_access: (false)
         require_account: (false)
+        allow_namespace_links: (false)
     }
     */
 

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -2,7 +2,7 @@
     This file should have parity with the actual database.
     For any changes to the database, those changes should be reflected here.
 
-    Schema Version: 2.6
+    Schema Version: 2.7
     This version number should be incremented with any change to the schema.
     Keep this up-to-date with db.py
 */
@@ -127,7 +127,11 @@ CREATE TABLE IF NOT EXISTS `lobbys` (
 CREATE TABLE IF NOT EXISTS `user_lobbys` (
     `user_id` INT NOT NULL,
     `lobby_id` INT NOT NULL,
+    -- `owner`=1 marks the lobby admin (creator). At most one per lobby.
+    -- `host`=1 marks a co-host (admin-promoted). The admin implicitly has
+    -- host privileges and need not also set host=1.
     `owner` BOOLEAN DEFAULT 0,
+    `host` BOOLEAN DEFAULT 0,
     FOREIGN KEY (`user_id`) REFERENCES `users`(`user_id`),
     FOREIGN KEY (`lobby_id`) REFERENCES `lobbys`(`lobby_id`)
 );

--- a/test/test_lobbys.py
+++ b/test/test_lobbys.py
@@ -269,3 +269,319 @@ def test_add_prompt_just_below_cap_succeeds(client, cursor, session, lobby_allow
     resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
     assert resp.status_code == 200
     assert _count_prompts(cursor, lobby_id) == ANON_LOBBY_PROMPT_CAP
+
+
+# Admin / host role split (2.7) ---------------------------------------------
+# `owner=1` means admin (one per lobby), `host=1` means co-host (many per
+# lobby). Admin implicitly has host privileges.
+
+def _login(client, user):
+    resp = client.post("/api/users/login", json={
+        "username": user["username"], "password": user["password"],
+    })
+    assert resp.status_code == 200
+
+
+def _logout(client):
+    client.post("/api/users/logout")
+
+
+def _join_user(client, lobby):
+    """Caller is responsible for being logged in. Joins as a registered user."""
+    resp = client.post(f"/api/lobbys/{lobby['lobby_id']}/join", json={
+        "passcode": lobby["passcode"],
+    })
+    assert resp.status_code == 200
+
+
+def _user_role(cursor, lobby_id, user_id):
+    """Returns ('admin' | 'host' | 'member' | None) for a given user in a lobby."""
+    cursor.execute(
+        "SELECT owner, host FROM user_lobbys WHERE lobby_id=%s AND user_id=%s",
+        (lobby_id, user_id),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    if row["owner"]:
+        return "admin"
+    if row["host"]:
+        return "host"
+    return "member"
+
+
+def test_promote_host_admin_only(client, cursor, user, user2, lobby):
+    lobby_id = lobby["lobby_id"]
+
+    # user2 joins as member
+    _login(client, user2)
+    _join_user(client, lobby)
+
+    # user2 cannot promote themselves (they aren't admin)
+    resp = client.patch(f"/api/lobbys/change_host/{lobby_id}", json={
+        "target_user_id": user2["user_id"],
+    })
+    assert resp.status_code == 401
+    assert _user_role(cursor, lobby_id, user2["user_id"]) == "member"
+
+    # Admin (user) promotes user2 successfully
+    _logout(client)
+    _login(client, user)
+    resp = client.patch(f"/api/lobbys/change_host/{lobby_id}", json={
+        "target_user_id": user2["user_id"],
+    })
+    assert resp.status_code == 200
+    assert _user_role(cursor, lobby_id, user2["user_id"]) == "host"
+
+
+def test_host_cannot_promote_others(client, cursor, user, user2, lobby):
+    # Promote user2 to host first.
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    # Now user2 (host, not admin) tries to promote someone — must 401.
+    # We don't have a 3rd user; instead, just call the endpoint and confirm
+    # the auth gate trips before the membership check.
+    _logout(client)
+    _login(client, user2)
+    resp = client.patch(f"/api/lobbys/change_host/{lobby_id}", json={
+        "target_user_id": 99999,
+    })
+    assert resp.status_code == 401
+
+
+def test_demote_host_admin_only(client, cursor, user, user2, lobby):
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    # Admin demotes successfully
+    resp = client.patch(f"/api/lobbys/remove_host/{lobby_id}", json={
+        "target_user_id": user2["user_id"],
+    })
+    assert resp.status_code == 200
+    assert _user_role(cursor, lobby_id, user2["user_id"]) == "member"
+
+
+def test_admin_cannot_self_demote_via_remove_host(client, cursor, user, lobby):
+    lobby_id = lobby["lobby_id"]
+    _login(client, user)
+    resp = client.patch(f"/api/lobbys/remove_host/{lobby_id}", json={
+        "target_user_id": user["user_id"],
+    })
+    assert resp.status_code == 400
+    assert _user_role(cursor, lobby_id, user["user_id"]) == "admin"
+
+
+def test_transfer_admin_swaps_roles(client, cursor, user, user2, lobby):
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    # Promote user2 to host first (target must be a member of the lobby).
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    # Admin transfers
+    resp = client.patch(f"/api/lobbys/transfer_admin/{lobby_id}", json={
+        "target_user_id": user2["user_id"],
+    })
+    assert resp.status_code == 200
+    assert _user_role(cursor, lobby_id, user["user_id"]) == "host"
+    assert _user_role(cursor, lobby_id, user2["user_id"]) == "admin"
+
+
+def test_transfer_admin_host_blocked(client, cursor, user, user2, lobby):
+    # Host (non-admin) attempting transfer must 401.
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    _logout(client)
+    _login(client, user2)
+    resp = client.patch(f"/api/lobbys/transfer_admin/{lobby_id}", json={
+        "target_user_id": user2["user_id"],
+    })
+    assert resp.status_code == 401
+
+
+def test_transfer_admin_to_plain_member_rejected(client, cursor, user, user2, lobby):
+    # API requires target to already be a host (matches UI semantics — the
+    # Transfer Admin button only appears on host rows).
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)  # user2 joins as plain member, not host
+    _logout(client)
+    _login(client, user)
+
+    resp = client.patch(f"/api/lobbys/transfer_admin/{lobby_id}", json={
+        "target_user_id": user2["user_id"],
+    })
+    assert resp.status_code == 400
+    assert _user_role(cursor, lobby_id, user["user_id"]) == "admin"
+    assert _user_role(cursor, lobby_id, user2["user_id"]) == "member"
+
+
+def test_transfer_admin_to_non_member_preserves_admin(cursor, db, user, lobby):
+    # Regression for the zero-admin race: if transfer_admin is invoked on a
+    # target with no user_lobbys row (simulating a TOCTOU between membership
+    # check and SQL), the helper must NOT demote the existing admin.
+    import wikispeedruns
+    lobby_id = lobby["lobby_id"]
+
+    # Caller is not a member of this lobby — simulates the racing scenario
+    # where the row was deleted between API check and SQL.
+    fake_user_id = 999999
+
+    result = wikispeedruns.lobbys.transfer_admin(lobby_id, fake_user_id)
+    assert result is False
+
+    # Refresh from DB. user_lobbys row state must still have user as admin.
+    db.commit()
+    assert _user_role(cursor, lobby_id, user["user_id"]) == "admin"
+    cursor.execute("SELECT COUNT(*) AS c FROM user_lobbys WHERE lobby_id=%s AND owner=1", (lobby_id,))
+    assert cursor.fetchone()["c"] == 1
+
+
+def test_delete_lobby_admin_only(client, cursor, user, user2, lobby):
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    # Host cannot delete
+    _logout(client)
+    _login(client, user2)
+    resp = client.delete(f"/api/lobbys/{lobby_id}")
+    assert resp.status_code == 401
+
+    # Admin can delete (this only hides; row still exists)
+    _logout(client)
+    _login(client, user)
+    resp = client.delete(f"/api/lobbys/{lobby_id}")
+    assert resp.status_code == 200
+
+
+def test_host_can_add_prompts(client, cursor, user, user2, lobby):
+    # Verify hosts retain prompt-add privilege (admin-or-host gate).
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    _logout(client)
+    _login(client, user2)
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 200
+    assert _count_prompts(cursor, lobby_id) == 1
+
+
+def test_host_can_delete_prompts(client, cursor, user, user2, lobby):
+    # Hosts retain prompt-delete privilege (admin-or-host gate).
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    # Seed one prompt as admin.
+    _seed_prompts(lobby_id, 1)
+    cursor.execute("SELECT prompt_id FROM lobby_prompts WHERE lobby_id=%s", (lobby_id,))
+    prompt_id = cursor.fetchone()["prompt_id"]
+
+    _logout(client)
+    _login(client, user2)
+    resp = client.delete(f"/api/lobbys/{lobby_id}/prompts", json={"prompts": [prompt_id]})
+    assert resp.status_code == 200
+    assert _count_prompts(cursor, lobby_id) == 0
+
+
+def test_admin_cannot_leave(client, cursor, user, lobby):
+    lobby_id = lobby["lobby_id"]
+    _login(client, user)
+    resp = client.delete(f"/api/lobbys/leave/{lobby_id}/")
+    assert resp.status_code == 400
+    assert _user_role(cursor, lobby_id, user["user_id"]) == "admin"
+
+
+def test_host_can_leave(client, cursor, user, user2, lobby):
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    _logout(client)
+    _login(client, user2)
+    resp = client.delete(f"/api/lobbys/leave/{lobby_id}/")
+    assert resp.status_code == 200
+    assert _user_role(cursor, lobby_id, user2["user_id"]) is None
+
+
+# Account-deletion handoff (2.7) --------------------------------------------
+
+def test_delete_account_host_preserves_lobby(client, cursor, user, user2, lobby):
+    # Co-host deleting their account must NOT delete the admin's lobby.
+    # Regression for the cohost-cascade bug.
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    _logout(client)
+    _login(client, user2)
+    resp = client.delete("/api/users/delete_account")
+    assert resp.status_code == 200
+
+    # Lobby still exists, admin still admin.
+    cursor.execute("SELECT COUNT(*) AS c FROM lobbys WHERE lobby_id=%s", (lobby_id,))
+    assert cursor.fetchone()["c"] == 1
+    assert _user_role(cursor, lobby_id, user["user_id"]) == "admin"
+    assert _user_role(cursor, lobby_id, user2["user_id"]) is None
+
+
+def test_delete_account_admin_with_host_transfers(client, cursor, user, user2, lobby):
+    # Admin deletes account; co-host inherits admin; lobby survives.
+    lobby_id = lobby["lobby_id"]
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    # Now delete admin's account.
+    resp = client.delete("/api/users/delete_account")
+    assert resp.status_code == 200
+
+    cursor.execute("SELECT COUNT(*) AS c FROM lobbys WHERE lobby_id=%s", (lobby_id,))
+    assert cursor.fetchone()["c"] == 1
+    assert _user_role(cursor, lobby_id, user2["user_id"]) == "admin"
+
+
+def test_delete_account_solo_admin_deletes_lobby(client, cursor, user, lobby):
+    # Admin alone deletes account → lobby gets purged.
+    lobby_id = lobby["lobby_id"]
+    _login(client, user)
+    resp = client.delete("/api/users/delete_account")
+    assert resp.status_code == 200
+
+    cursor.execute("SELECT COUNT(*) AS c FROM lobbys WHERE lobby_id=%s", (lobby_id,))
+    assert cursor.fetchone()["c"] == 0

--- a/test/test_lobbys.py
+++ b/test/test_lobbys.py
@@ -1,3 +1,4 @@
+import json
 from pydoc import cli
 import pytest
 
@@ -10,6 +11,22 @@ def lobby(cursor, user):
     cursor.execute(f"SELECT * FROM lobbys WHERE lobby_id={lobby_id}")
     yield cursor.fetchone()
 
+    cursor.execute("DELETE FROM lobby_prompts")
+    cursor.execute("DELETE FROM user_lobbys")
+    cursor.execute("DELETE FROM lobbys")
+
+
+@pytest.fixture
+def lobby_allow_anyone(cursor, user):
+    lobby_id = wikispeedruns.lobbys.create_lobby(
+        user["user_id"],
+        rules=json.dumps({"allow_anyone_add_prompts": True}),
+    )
+
+    cursor.execute(f"SELECT * FROM lobbys WHERE lobby_id={lobby_id}")
+    yield cursor.fetchone()
+
+    cursor.execute("DELETE FROM lobby_prompts")
     cursor.execute("DELETE FROM user_lobbys")
     cursor.execute("DELETE FROM lobbys")
 
@@ -101,3 +118,154 @@ def test_permissions_user(client, session2, lobby):
         "language": "en"
     })
     assert resp.status_code == 401
+
+
+# Prompt submission permission matrix --------------------------------------
+# Covers add_lobby_prompt under the allow_anyone_add_prompts rule, for
+# owners, logged-in members, anonymous members, and non-members.
+
+PROMPT_PAYLOAD = {"start": "Foo", "end": "Bar", "language": "en"}
+
+
+def _join_as_anon(client, lobby, name="anon"):
+    resp = client.post(f"/api/lobbys/{lobby['lobby_id']}/join", json={
+        "name": name,
+        "passcode": lobby["passcode"],
+    })
+    assert resp.status_code == 200
+
+
+def _join_as_user(client, lobby):
+    resp = client.post(f"/api/lobbys/{lobby['lobby_id']}/join", json={
+        "passcode": lobby["passcode"],
+    })
+    assert resp.status_code == 200
+
+
+def _count_prompts(cursor, lobby_id):
+    cursor.execute("SELECT COUNT(*) AS c FROM lobby_prompts WHERE lobby_id=%s", (lobby_id,))
+    return cursor.fetchone()["c"]
+
+
+def test_add_prompt_owner_default(client, cursor, session, lobby):
+    # Owner can always add prompts, regardless of allow_anyone_add_prompts.
+    lobby_id = lobby["lobby_id"]
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 200
+    assert _count_prompts(cursor, lobby_id) == 1
+
+
+def test_add_prompt_owner_allow_anyone(client, cursor, session, lobby_allow_anyone):
+    lobby_id = lobby_allow_anyone["lobby_id"]
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 200
+    assert _count_prompts(cursor, lobby_id) == 1
+
+
+def test_add_prompt_member_user_blocked_by_default(client, cursor, session2, lobby):
+    # Logged-in non-owner member: should NOT be able to add when rule is off.
+    lobby_id = lobby["lobby_id"]
+    _join_as_user(client, lobby)
+
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 401
+    assert _count_prompts(cursor, lobby_id) == 0
+
+
+def test_add_prompt_member_user_allowed_when_rule_on(client, cursor, session2, lobby_allow_anyone):
+    # Logged-in non-owner member: should be allowed when rule is on.
+    lobby_id = lobby_allow_anyone["lobby_id"]
+    _join_as_user(client, lobby_allow_anyone)
+
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 200
+    assert _count_prompts(cursor, lobby_id) == 1
+
+
+def test_add_prompt_anon_member_blocked_by_default(client, cursor, lobby):
+    # Anonymous (passcode-joined) member: should NOT be able to add when rule is off.
+    lobby_id = lobby["lobby_id"]
+    _join_as_anon(client, lobby)
+
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 401
+    assert _count_prompts(cursor, lobby_id) == 0
+
+
+def test_add_prompt_anon_member_allowed_when_rule_on(client, cursor, lobby_allow_anyone):
+    # Anonymous (passcode-joined) member: allowed when rule is on. This is the
+    # regression case from code review — previously @check_user 401'd them.
+    lobby_id = lobby_allow_anyone["lobby_id"]
+    _join_as_anon(client, lobby_allow_anyone)
+
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 200
+    assert _count_prompts(cursor, lobby_id) == 1
+
+
+def test_add_prompt_non_member_anon_rejected(client, cursor, lobby_allow_anyone):
+    # Anon who never joined the lobby is rejected even with rule on.
+    lobby_id = lobby_allow_anyone["lobby_id"]
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 401
+    assert _count_prompts(cursor, lobby_id) == 0
+
+
+def test_add_prompt_non_member_user_rejected(client, cursor, session2, lobby_allow_anyone):
+    # Logged-in user who never joined is rejected even with rule on.
+    lobby_id = lobby_allow_anyone["lobby_id"]
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 401
+    assert _count_prompts(cursor, lobby_id) == 0
+
+
+from apis.lobbys_api import ANON_LOBBY_PROMPT_CAP
+
+
+def _seed_prompts(lobby_id, n):
+    for i in range(n):
+        wikispeedruns.lobbys.add_lobby_prompt(lobby_id, f"Start_{i}", f"End_{i}", "en")
+
+
+def test_add_prompt_capped_when_anon_enabled(client, cursor, session, lobby_allow_anyone):
+    # When allow_anyone_add_prompts is on, the lobby is capped at
+    # ANON_LOBBY_PROMPT_CAP total prompts. Cap applies to all submitters,
+    # including the owner — owner deletes to free space.
+    lobby_id = lobby_allow_anyone["lobby_id"]
+    _seed_prompts(lobby_id, ANON_LOBBY_PROMPT_CAP)
+    assert _count_prompts(cursor, lobby_id) == ANON_LOBBY_PROMPT_CAP
+
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 400
+    assert _count_prompts(cursor, lobby_id) == ANON_LOBBY_PROMPT_CAP
+
+
+def test_add_prompt_cap_blocks_anon_member(client, cursor, lobby_allow_anyone):
+    lobby_id = lobby_allow_anyone["lobby_id"]
+    _seed_prompts(lobby_id, ANON_LOBBY_PROMPT_CAP)
+
+    _join_as_anon(client, lobby_allow_anyone)
+
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 400
+    assert _count_prompts(cursor, lobby_id) == ANON_LOBBY_PROMPT_CAP
+
+
+def test_no_cap_when_anon_disabled(client, cursor, session, lobby):
+    # Without allow_anyone_add_prompts, no cap — only the owner can add
+    # anyway, so the abuse vector doesn't exist.
+    lobby_id = lobby["lobby_id"]
+    _seed_prompts(lobby_id, ANON_LOBBY_PROMPT_CAP)
+
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 200
+    assert _count_prompts(cursor, lobby_id) == ANON_LOBBY_PROMPT_CAP + 1
+
+
+def test_add_prompt_just_below_cap_succeeds(client, cursor, session, lobby_allow_anyone):
+    lobby_id = lobby_allow_anyone["lobby_id"]
+    _seed_prompts(lobby_id, ANON_LOBBY_PROMPT_CAP - 1)
+
+    resp = client.post(f"/api/lobbys/{lobby_id}/prompts", json=PROMPT_PAYLOAD)
+    assert resp.status_code == 200
+    assert _count_prompts(cursor, lobby_id) == ANON_LOBBY_PROMPT_CAP

--- a/test/test_lobbys.py
+++ b/test/test_lobbys.py
@@ -585,3 +585,52 @@ def test_delete_account_solo_admin_deletes_lobby(client, cursor, user, lobby):
 
     cursor.execute("SELECT COUNT(*) AS c FROM lobbys WHERE lobby_id=%s", (lobby_id,))
     assert cursor.fetchone()["c"] == 0
+
+
+def test_delete_account_handoff_picks_min_user_id(client, cursor, db, user, user2, lobby):
+    # When multiple co-hosts exist, account-deletion handoff picks MIN(user_id)
+    # deterministically. Verifies the handoff query matches its documented
+    # behavior.
+    import wikispeedruns
+    lobby_id = lobby["lobby_id"]
+
+    # Add a third user with a higher user_id and make them a co-host too.
+    # The admin is user (user_id=N). user2 (user_id=M>N) joins and becomes
+    # host. We add a synthetic third (higher id again) directly so MIN
+    # selection is testable without a third real account fixture.
+    _login(client, user2)
+    _join_user(client, lobby)
+    _logout(client)
+    _login(client, user)
+    client.patch(f"/api/lobbys/change_host/{lobby_id}", json={"target_user_id": user2["user_id"]})
+
+    # Insert a synthetic third user-lobby row with a deliberately higher id
+    # so we can confirm MIN selection.
+    cursor.execute("SELECT MAX(user_id) AS m FROM users")
+    max_uid = cursor.fetchone()["m"]
+    high_uid = max_uid + 100
+    cursor.execute(
+        "INSERT INTO users (user_id, username, email, join_date) VALUES (%s, %s, %s, CURRENT_DATE())",
+        (high_uid, f"synth_host_{high_uid}", f"synth_{high_uid}@test.com"),
+    )
+    cursor.execute(
+        "INSERT INTO user_lobbys (user_id, lobby_id, owner, host) VALUES (%s, %s, 0, 1)",
+        (high_uid, lobby_id),
+    )
+    db.commit()
+
+    # Delete admin's account. Handoff should pick user2 (lower id), not the
+    # synthetic high-id user.
+    resp = client.delete("/api/users/delete_account")
+    assert resp.status_code == 200
+
+    # Refresh and verify role assignment.
+    db.commit()
+    assert _user_role(cursor, lobby_id, user2["user_id"]) == "admin"
+    assert _user_role(cursor, lobby_id, high_uid) == "host"
+
+    # Cleanup synthetic user (the per-test lobby teardown handles user_lobbys).
+    cursor.execute("DELETE FROM user_lobbys WHERE user_id=%s", (high_uid,))
+    cursor.execute("DELETE FROM users WHERE user_id=%s", (high_uid,))
+
+

--- a/wikispeedruns/leaderboards.py
+++ b/wikispeedruns/leaderboards.py
@@ -64,8 +64,11 @@ def _query_sort_expr(table, sort_mode, sort_asc):
     dir = "ASC" if sort_asc else "DESC"    
     if (sort_mode == 'time'):
         sort_exp = f'finished DESC, play_time {dir}'
-    elif (sort_mode == 'length' or sort_mode == 'penalty'):
+    elif (sort_mode == 'length'):
         sort_exp = f"finished DESC, JSON_LENGTH({table}.`path`, '$.path') {dir}, play_time {dir}"
+    elif (sort_mode == 'penalty'):
+        penalty_expr = f"COALESCE(JSON_EXTRACT({table}.`path`, CONCAT('$.path[', JSON_LENGTH({table}.`path`, '$.path') - 1, '].penaltyTime')), 0)"
+        sort_exp = f"finished DESC, (play_time + {penalty_expr}) {dir}"
     elif (sort_mode == 'start'):
         sort_exp = f'start_time {dir}'
     else:

--- a/wikispeedruns/lobbys.py
+++ b/wikispeedruns/lobbys.py
@@ -308,14 +308,31 @@ def join_lobby_as_user(lobby_id: int, user_id: int) -> bool:
 
 
 def get_lobby_user_info(lobby_id: int, user_id: Optional[int]) -> Optional[dict]:
-    query = "SELECT owner FROM user_lobbys WHERE lobby_id=%s AND user_id=%s"
+    # owner=1 -> admin. host=1 -> co-host. Admin implies host privileges.
+    # Returned dict carries both raw columns and derived `is_host` for
+    # convenience at call sites.
+    query = "SELECT owner, host FROM user_lobbys WHERE lobby_id=%s AND user_id=%s"
 
     if (user_id == None): return None
 
     db = get_db()
     with db.cursor(cursor=DictCursor) as cursor:
         cursor.execute(query, (lobby_id, user_id))
-        return cursor.fetchone()
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        row["is_host"] = bool(row["owner"]) or bool(row["host"])
+        return row
+
+
+def is_lobby_admin(lobby_id: int, user_id: Optional[int]) -> bool:
+    info = get_lobby_user_info(lobby_id, user_id)
+    return bool(info and info["owner"])
+
+
+def is_lobby_host(lobby_id: int, user_id: Optional[int]) -> bool:
+    info = get_lobby_user_info(lobby_id, user_id)
+    return bool(info and info["is_host"])
 
 
 # Lobby Runs
@@ -405,7 +422,8 @@ def get_user_lobbys(user_id: int):
 
 
 def count_lobby_hosts(lobby_id: int) -> int:
-    query = "SELECT COUNT(*) as cnt FROM user_lobbys WHERE lobby_id=%s AND owner=1"
+    # Counts anyone with elevated privileges: admin (owner=1) or co-host (host=1).
+    query = "SELECT COUNT(*) as cnt FROM user_lobbys WHERE lobby_id=%s AND (owner=1 OR host=1)"
     db = get_db()
     with db.cursor(cursor=DictCursor) as cursor:
         cursor.execute(query, (lobby_id,))
@@ -415,7 +433,7 @@ def count_lobby_hosts(lobby_id: int) -> int:
 def add_lobby_host(lobby_id: int, target_user_id: int):
     query = """
     UPDATE user_lobbys
-    SET owner=1
+    SET host=1
     WHERE user_id=%(target_user_id)s AND lobby_id=%(lobby_id)s
     """
 
@@ -432,7 +450,7 @@ def add_lobby_host(lobby_id: int, target_user_id: int):
 def remove_lobby_host(lobby_id: int, target_user_id: int):
     query = """
     UPDATE user_lobbys
-    SET owner=0
+    SET host=0
     WHERE user_id=%(target_user_id)s AND lobby_id=%(lobby_id)s
     """
 
@@ -446,10 +464,58 @@ def remove_lobby_host(lobby_id: int, target_user_id: int):
         return True
 
 
+def transfer_admin(lobby_id: int, target_user_id: int) -> bool:
+    """Move admin status from the current admin to target_user_id.
+
+    Target must already be a member of the lobby. The previous admin is
+    demoted to host=1 so they retain elevated privileges (but no longer the
+    admin-only ones).
+
+    Returns False (without committing any change) if target has no
+    user_lobbys row — protects against a TOCTOU between the API's
+    membership check and the SQL, which could otherwise leave the lobby
+    with zero admins.
+    """
+    db = get_db()
+    with db.cursor() as cursor:
+        # Promote target first so we know we have a new admin before
+        # demoting the old one. Excludes target from the demote step so a
+        # self-transfer (no-op) doesn't accidentally clear owner.
+        cursor.execute(
+            "UPDATE user_lobbys SET owner=1, host=0 WHERE lobby_id=%s AND user_id=%s",
+            (lobby_id, target_user_id),
+        )
+        if cursor.rowcount == 0:
+            # Target isn't a member — abort. No change has been committed.
+            return False
+
+        cursor.execute(
+            "UPDATE user_lobbys SET owner=0, host=1 WHERE lobby_id=%s AND owner=1 AND user_id != %s",
+            (lobby_id, target_user_id),
+        )
+        db.commit()
+    return True
+
+
+def find_handoff_target(lobby_id: int, exclude_user_id: int) -> Optional[int]:
+    """Pick a deterministic host to receive admin on handoff. Returns None
+    if no other host exists for the lobby."""
+    query = """
+    SELECT MIN(user_id) AS user_id
+    FROM user_lobbys
+    WHERE lobby_id=%s AND host=1 AND user_id != %s
+    """
+    db = get_db()
+    with db.cursor(cursor=DictCursor) as cursor:
+        cursor.execute(query, (lobby_id, exclude_user_id))
+        row = cursor.fetchone()
+        return row["user_id"] if row and row["user_id"] is not None else None
+
+
 
 def get_lobby_users(lobby_id: int):
     query = """
-    SELECT DISTINCT users.username, users.user_id, owner FROM user_lobbys
+    SELECT DISTINCT users.username, users.user_id, owner, host FROM user_lobbys
     LEFT JOIN users ON user_lobbys.user_id = users.user_id
     WHERE lobby_id=%s
     """

--- a/wikispeedruns/lobbys.py
+++ b/wikispeedruns/lobbys.py
@@ -223,6 +223,13 @@ def add_lobby_prompt(lobby_id: int, start: int, end: int, language: str) -> bool
 
         return True
 
+
+def count_lobby_prompts(lobby_id: int) -> int:
+    db = get_db()
+    with db.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM lobby_prompts WHERE lobby_id=%s", (lobby_id,))
+        return cursor.fetchone()[0]
+
 # passing session here is a bit messy
 def get_lobby_prompts(lobby_id: int, prompt_id: Optional[int]=None, session: Optional[dict]=None) -> List[LobbyPrompt]:
     ## TODO user_id?]

--- a/wikispeedruns/lobbys.py
+++ b/wikispeedruns/lobbys.py
@@ -397,14 +397,16 @@ def get_user_lobbys(user_id: int):
         return results
 
 
-def change_lobby_host(lobby_id: int, target_user_id: int):
-    remove_host_query = """
-    UPDATE user_lobbys
-    SET owner=0
-    WHERE owner=1 AND lobby_id=%(lobby_id)s
-    """
+def count_lobby_hosts(lobby_id: int) -> int:
+    query = "SELECT COUNT(*) as cnt FROM user_lobbys WHERE lobby_id=%s AND owner=1"
+    db = get_db()
+    with db.cursor(cursor=DictCursor) as cursor:
+        cursor.execute(query, (lobby_id,))
+        return cursor.fetchone()["cnt"]
 
-    set_host_query = """
+
+def add_lobby_host(lobby_id: int, target_user_id: int):
+    query = """
     UPDATE user_lobbys
     SET owner=1
     WHERE user_id=%(target_user_id)s AND lobby_id=%(lobby_id)s
@@ -412,16 +414,28 @@ def change_lobby_host(lobby_id: int, target_user_id: int):
 
     db = get_db()
     with db.cursor() as cursor:
-        cursor.execute(remove_host_query, {
-            "lobby_id": lobby_id,
-        })
-
-        cursor.execute(set_host_query, {
+        cursor.execute(query, {
             "target_user_id": target_user_id,
             "lobby_id": lobby_id
         })
         db.commit()
+        return True
 
+
+def remove_lobby_host(lobby_id: int, target_user_id: int):
+    query = """
+    UPDATE user_lobbys
+    SET owner=0
+    WHERE user_id=%(target_user_id)s AND lobby_id=%(lobby_id)s
+    """
+
+    db = get_db()
+    with db.cursor() as cursor:
+        cursor.execute(query, {
+            "target_user_id": target_user_id,
+            "lobby_id": lobby_id
+        })
+        db.commit()
         return True
 
 


### PR DESCRIPTION
a number of lobby options as mentioned in community requests

- allow multiple hosts in a lobby (not a toggle option, just available for all lobbies). First hosts still have to be designated by original lobby creator #626 
- added option to allow non-host players to submit prompts #636 
- added lobby option to allow all namespace links. Added to quickplay as an option as well #649 
- fixed a leaderboard ranking bug in penalty mode #653 